### PR TITLE
homebrew HEAD 安装的二进制不检查更新

### DIFF
--- a/lean/check_update.go
+++ b/lean/check_update.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"encoding/json"
-	"log"
 
 	"github.com/coreos/go-semver/semver"
+	"github.com/fatih/color"
 	"github.com/leancloud/lean-cli/lean/version"
 	"github.com/levigross/grequests"
 )
@@ -42,7 +42,7 @@ func checkUpdate() error {
 	latest := semver.New(result.Version)
 
 	if current.LessThan(*latest) {
-		log.Printf("发现新版本 %s，变更如下：\r\n%s\r\n您可以通过以下命令升级：%s", result.Version, result.ChangeLog, updateCommand())
+		color.Green("发现新版本 %s，变更如下：\r\n%s \r\n您可以通过以下命令升级：%s", result.Version, result.ChangeLog, updateCommand())
 	}
 
 	return nil

--- a/lean/check_update.go
+++ b/lean/check_update.go
@@ -25,6 +25,9 @@ func updateCommand() string {
 }
 
 func checkUpdate() error {
+	if pkgType == "homebrew-head" {
+		return nil
+	}
 	resp, err := grequests.Get(checkUpdateURL, nil)
 	if err != nil {
 		return err

--- a/lean/deploy_action.go
+++ b/lean/deploy_action.go
@@ -114,20 +114,21 @@ func deployFromGit(appID string, groupName string) error {
 }
 
 func deployAction(*cli.Context) error {
-	// TODO: specific app
 	appID, err := apps.GetCurrentAppID("")
 	if err == apps.ErrNoAppLinked {
 		log.Fatalln("没有关联任何 app，请使用 lean switch 来关联应用。")
 	}
-
 	if err != nil {
 		return newCliError(err)
 	}
 
+	op.Write("获取部署分组信息")
 	groupName, err := determineGroupName(appID)
 	if err != nil {
+		op.Failed()
 		return newCliError(err)
 	}
+	op.Successed()
 
 	if groupName == "staging" {
 		op.Write("准备部署应用到预备环境")

--- a/lean/main.go
+++ b/lean/main.go
@@ -104,6 +104,11 @@ func main() {
 				},
 			},
 		},
+		{
+			Name:   "publish",
+			Usage:  "部署当前预备环境的代码至生产环境",
+			Action: publishAction,
+		},
 	}
 
 	app.Run(os.Args)

--- a/lean/publish_action.go
+++ b/lean/publish_action.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"log"
+
+	"github.com/codegangsta/cli"
+	"github.com/leancloud/lean-cli/lean/api"
+	"github.com/leancloud/lean-cli/lean/apps"
+)
+
+func publishAction(c *cli.Context) error {
+	appID, err := apps.GetCurrentAppID("")
+	if err == apps.ErrNoAppLinked {
+		log.Fatalln("没有关联任何 app，请使用 lean switch 来关联应用。")
+	}
+	if err != nil {
+		return newCliError(err)
+	}
+
+	info, err := api.GetAppInfo(appID)
+	if err != nil {
+		return newCliError(err)
+	}
+
+	if info.LeanEngineMode == "free" {
+		return cli.NewExitError("免费版应用使用 lean deploy 即可将代码部署到生产环境，无需使用此命令。", 1)
+	}
+
+	return nil
+}


### PR DESCRIPTION
使用 `brew install lean-cli --HEAD` 方式安装命令的用户，不自动检查更新。