### PR TITLE
fix: don't show `deploy failed` when last deploy log's level is not error

### DIFF
--- a/lean/api/event_poller.go
+++ b/lean/api/event_poller.go
@@ -55,18 +55,19 @@ func PollEvents(appID string, tok string, writer io.Writer) (bool, error) {
 			return false, err
 		}
 		for i := len(event.Events) - 1; i >= 0; i-- {
-			if spinner != nil {
-				spinner.End()
-			}
-
 			e := event.Events[i]
 
-			spinner = chrysanthemum.New(e.Content).Start()
-
-			from = e.Time
-			if strings.ToLower(e.Level) == "error" {
-				ok = false
+			if spinner != nil {
+				if ok {
+					spinner.Successed()
+				} else {
+					spinner.Failed()
+				}
 			}
+
+			spinner = chrysanthemum.New(e.Content).Start()
+			from = e.Time
+			ok = strings.ToLower(e.Level) != "error"
 		}
 		if !event.MoreEvent {
 			break

--- a/lean/main.go
+++ b/lean/main.go
@@ -268,6 +268,11 @@ func init() {
 }
 
 func main() {
+	if os.Getenv("LEAN_CLI_DEBUG") == "1" {
+		run()
+		return
+	}
+
 	raven.SetTagsContext(map[string]string{
 		"version": version.Version,
 		"OS":      runtime.GOOS,


### PR DESCRIPTION
close: #135