### PR TITLE
feat: persistence app router cache

### DIFF
--- a/lean/api/app_router.go
+++ b/lean/api/app_router.go
@@ -1,9 +1,13 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"path/filepath"
 
 	"github.com/leancloud/lean-cli/lean/api/regions"
+	"github.com/leancloud/lean-cli/lean/utils"
 	"github.com/leancloud/lean-cli/lean/version"
 	"github.com/levigross/grequests"
 )
@@ -46,4 +50,20 @@ func GetAppRegion(appID string) (regions.Region, error) {
 	default:
 		return regions.Invalid, fmt.Errorf("invalid region server: %s", result.APIServer)
 	}
+}
+
+func saveRouterCache() error {
+	data, err := json.MarshalIndent(routerCache, "", "  ")
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(filepath.Join(utils.ConfigDir(), "leancloud", "app_router.json"), data, 0644)
+}
+
+func init() {
+	data, err := ioutil.ReadFile(filepath.Join(utils.ConfigDir(), "leancloud", "app_router.json"))
+	if err != nil {
+		return
+	}
+	json.Unmarshal(data, &routerCache)
 }

--- a/lean/api/apps.go
+++ b/lean/api/apps.go
@@ -14,6 +14,7 @@ type GetAppListResult struct {
 }
 
 // GetAppList returns the current user's all LeanCloud application
+// this will also update the app router cache
 func GetAppList(region regions.Region) ([]*GetAppListResult, error) {
 	client := NewClient(region)
 
@@ -24,7 +25,18 @@ func GetAppList(region regions.Region) ([]*GetAppListResult, error) {
 
 	var result []*GetAppListResult
 	err = resp.JSON(&result)
-	return result, err
+	if err != nil {
+		return nil, err
+	}
+
+	for _, app := range result {
+		routerCache[app.AppID] = region
+	}
+	if err = saveRouterCache(); err != nil {
+		return nil, err
+	}
+
+	return result, nil
 }
 
 // DeployImage will deploy the engine group with specify image tag

--- a/lean/info_action.go
+++ b/lean/info_action.go
@@ -3,30 +3,48 @@ package main
 import (
 	"fmt"
 
+	"github.com/aisk/chrysanthemum"
 	"github.com/codegangsta/cli"
 	"github.com/leancloud/lean-cli/lean/api"
 	"github.com/leancloud/lean-cli/lean/apps"
 )
 
 func infoAction(c *cli.Context) error {
+	bar := chrysanthemum.New("获取用户信息").Start()
 	userInfo, err := api.GetUserInfo()
 	if err == api.ErrNotLogined {
 		return cli.NewExitError("未登录，请先使用 `lean login` 命令登录 LeanCloud。", 1)
 	}
 	if err != nil {
+		bar.Failed()
 		return newCliError(err)
 	}
+	bar.End()
 	fmt.Printf("当前登录用户: %s (%s)\r\n", userInfo.UserName, userInfo.Email)
 
+	bar = chrysanthemum.New("获取应用信息").Start()
 	appID, err := apps.GetCurrentAppID("")
 	if err == apps.ErrNoAppLinked {
+		bar.End()
 		fmt.Println("当前目录没有关联任何 LeanCloud 应用。")
 		return nil
+	} else if err != nil {
+		bar.Failed()
+		return newCliError(err)
+	}
+	region, err := api.GetAppRegion(appID)
+	if err != nil {
+		bar.Failed()
+		return newCliError(err)
 	}
 	appInfo, err := api.GetAppInfo(appID)
 	if err != nil {
+		bar.Failed()
 		return newCliError(err)
 	}
+	bar.End()
+
+	fmt.Printf("当前目录关联节点：%s \r\n", region)
 	fmt.Printf("当前目录关联应用：%s (%s)\r\n", appInfo.AppName, appInfo.AppID)
 
 	return nil


### PR DESCRIPTION
之前都是统一通过 https://app-router.leancloud.cn/1/route?appId=xxx 来判断节点信息的，后来实际上美国节点的应用信息并不能在 app router 上查询到（但是带 - 后缀的可以查询），导致有一批美国节点的应用部署的时候会出现问题。

这个 PR 在根据节点获取应用列表的时候会把列表中所以应用的 app router 信息保存到磁盘，就不必担心此问题了。