### PR TITLE
避免出现远程调试测试环境出错的情况

### DIFF
--- a/lean/console/index_html.go
+++ b/lean/console/index_html.go
@@ -136,7 +136,7 @@ const indexHTML = `
               return $('#result').html(err.message || err);
             }
             var apiEndpoint = $('#isCall').is(':checked') ? '/1.1/call/' : '/1.1/functions/';
-            var url = "http://localhost:" + leanenginePort + apiEndpoint + $('#functions').val();
+            var url = "http://" + window.location.hostname + ":" + leanenginePort + apiEndpoint + $('#functions').val();
             request(url, data, user);
           })
         } catch(e){


### PR DESCRIPTION
方便将测试环境部署在自己内网服务器上。
避免内网其他机器访问内网服务器测试云代码的时候报错。