### PR TITLE
:sparkles: support third party command

### DIFF
--- a/commands/app.go
+++ b/commands/app.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"log"
 	"net/url"
 	"os"
 	"os/exec"
@@ -12,27 +11,6 @@ import (
 	"github.com/leancloud/lean-cli/version"
 	"github.com/pkg/browser"
 )
-
-func thirdPartyCommand(c *cli.Context, _cmdName string) {
-	cmdName := "lean-" + _cmdName
-
-	// executeble not found:
-	execPath, err := exec.LookPath(cmdName)
-	if e, ok := err.(*exec.Error); ok {
-		if e.Err == exec.ErrNotFound {
-			cli.ShowAppHelp(c)
-			return
-		}
-	}
-	cmd := exec.Command(execPath, c.Args()[1:]...)
-	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	err = cmd.Run()
-	if err != nil {
-		log.Fatal(err)
-	}
-}
 
 // Run the command line
 func Run(args []string) {

--- a/commands/third_party_command.go
+++ b/commands/third_party_command.go
@@ -1,0 +1,63 @@
+package commands
+
+import (
+	"log"
+	"os"
+	"os/exec"
+
+	"github.com/codegangsta/cli"
+	"github.com/leancloud/lean-cli/api"
+	"github.com/leancloud/lean-cli/apps"
+)
+
+func thirdPartyCommand(c *cli.Context, _cmdName string) {
+	cmdName := "lean-" + _cmdName
+
+	// executeble not found:
+	execPath, err := exec.LookPath(cmdName)
+	if e, ok := err.(*exec.Error); ok {
+		if e.Err == exec.ErrNotFound {
+			cli.ShowAppHelp(c)
+			return
+		}
+		log.Fatal(err)
+	} else if err != nil {
+		log.Fatal(err)
+	}
+
+	cmd := exec.Command(execPath, c.Args()[1:]...)
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+
+	appID, err := apps.GetCurrentAppID(".")
+	if err == nil {
+		region, err := api.GetAppRegion(appID)
+		if err != nil {
+			log.Fatal(err)
+		}
+		appInfo, err := api.GetAppInfo(appID)
+		if err != nil {
+			log.Fatal(err)
+		}
+		envs := []string{
+			"LEANCLOUD_APP_ID=" + appInfo.AppID,
+			"LEANCLOUD_APP_KEY=" + appInfo.AppKey,
+			"LEANCLOUD_APP_MASTER_KEY=" + appInfo.MasterKey,
+			"LEANCLOUD_APP_HOOK_KEY=" + appInfo.HookKey,
+			"LEANCLOUD_APP_ENV=" + "development",
+			"LEANCLOUD_REGION=" + region.String(),
+		}
+		for _, env := range envs {
+			cmd.Env = append(cmd.Env, env)
+		}
+	}
+	if err != nil && err != apps.ErrNoAppLinked {
+		log.Fatal(err)
+	}
+
+	err = cmd.Run()
+	if err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
现在执行 `$ lean xxxxxxx` ，会在 `$PATH` 中寻找 `lean-xxxxxxx` 的可执行文件，如果找到，自动执行此命令。

并且如果当前目录是个 LeanEngine 项目目录，在 `lean-xxxxxxx` 进程的环境变量中，可以获得 `$LEANCLOUD_APP_ID` 等环境变量。