### PR TITLE
:hammer: refactor makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,42 +5,63 @@ RESOURCES=$(wildcard ./console/resources/*.html)
 
 all: binaries msi deb
 
-binaries: $(SRC)
-	GOOS=darwin GOARCH=amd64 POSTFIX= make $(OUTPUT)/lean-darwin-amd64
-	GOOS=windows GOARCH=386 POSTFIX=.exe make $(OUTPUT)/lean-windows-386.exe
-	GOOS=windows GOARCH=amd64 POSTFIX=.exe make $(OUTPUT)/lean-windows-amd64.exe
-	GOOS=linux GOARCH=amd64 POSTFIX= make $(OUTPUT)/lean-linux-amd64
-	GOOS=linux GOARCH=386 POSTFIX= make $(OUTPUT)/lean-linux-386
-
 msi:
-	wixl -a x86 packaging/msi/lean-cli-x86.wxs -o $(OUTPUT)/lean-cli-setup-x86.msi
-	wixl -a x64 packaging/msi/lean-cli-x64.wxs -o $(OUTPUT)/lean-cli-setup-x64.msi
+	make $(OUTPUT)/lean-cli-setup-x86.msi
+	make $(OUTPUT)/lean-cli-setup-x64.msi
+
+$(OUTPUT)/lean-cli-setup-x86.msi: $(OUTPUT)/lean-windows-x86.exe
+	wixl -a x86 packaging/msi/lean-cli-x86.wxs -o $@
+
+$(OUTPUT)/lean-cli-setup-x64.msi: $(OUTPUT)/lean-windows-x64.exe
+	wixl -a x64 packaging/msi/lean-cli-x64.wxs -o $@
 
 deb:
+	make $(OUTPUT)/lean-cli-x86.deb
+	make $(OUTPUT)/lean-cli-x64.deb
+
+$(OUTPUT)/lean-cli-x86.deb: $(OUTPUT)/lean-linux-x86
 	mkdir -p $(OUTPUT)/x86-deb/DEBIAN/
 	mkdir -p $(OUTPUT)/x86-deb/usr/bin/
-	cp $(OUTPUT)/lean-linux-386 $(OUTPUT)/x86-deb/usr/bin/lean
+	cp $(OUTPUT)/lean-linux-x86 $(OUTPUT)/x86-deb/usr/bin/lean
 	cp packaging/deb/control-x86 $(OUTPUT)/x86-deb/DEBIAN/control
-	dpkg-deb --build $(OUTPUT)/x86-deb $(OUTPUT)/lean-cli-x86.deb
+	dpkg-deb --build $(OUTPUT)/x86-deb $@
+	rm -rf $(OUTPUT)/x86-deb
+
+$(OUTPUT)/lean-cli-x64.deb: $(OUTPUT)/lean-linux-x64
 	mkdir -p $(OUTPUT)/x64-deb/DEBIAN/
 	mkdir -p $(OUTPUT)/x64-deb/usr/bin/
-	cp $(OUTPUT)/lean-linux-amd64 $(OUTPUT)/x64-deb/usr/bin/lean
+	cp $(OUTPUT)/lean-linux-x64 $(OUTPUT)/x64-deb/usr/bin/lean
 	cp packaging/deb/control-x64 $(OUTPUT)/x64-deb/DEBIAN/control
-	dpkg-deb --build $(OUTPUT)/x64-deb $(OUTPUT)/lean-cli-x64.deb
+	dpkg-deb --build $(OUTPUT)/x64-deb $@
+	rm -rf $(OUTPUT)/x64-deb
 
-$(OUTPUT)/lean-$(GOOS)-$(GOARCH)$(POSTFIX): $(SRC)
-	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o $@ -ldflags=$(LDFLAGS) github.com/leancloud/lean-cli/lean
+binaries: $(SRC)
+	make $(OUTPUT)/lean-windows-x86.exe
+	make $(OUTPUT)/lean-windows-x64.exe
+	make $(OUTPUT)/lean-darwin-x64
+	make $(OUTPUT)/lean-linux-x86
+	make $(OUTPUT)/lean-linux-x64
+
+$(OUTPUT)/lean-windows-x86.exe: $(SRC) resources
+	GOOS=windows GOARCH=386 go build -o $@ -ldflags=$(LDFLAGS) github.com/leancloud/lean-cli/lean
+
+$(OUTPUT)/lean-windows-x64.exe: $(SRC) resources
+	GOOS=windows GOARCH=amd64 go build -o $@ -ldflags=$(LDFLAGS) github.com/leancloud/lean-cli/lean
+
+$(OUTPUT)/lean-darwin-x64: $(SRC) resources
+	GOOS=darwin GOARCH=amd64 go build -o $@ -ldflags=$(LDFLAGS) github.com/leancloud/lean-cli/lean
+
+$(OUTPUT)/lean-linux-x86: $(SRC) resources
+	GOOS=linux GOARCH=386 go build -o $@ -ldflags=$(LDFLAGS) github.com/leancloud/lean-cli/lean
+
+$(OUTPUT)/lean-linux-x64: $(SRC) resources
+	GOOS=linux GOARCH=amd64 go build -o $@ -ldflags=$(LDFLAGS) github.com/leancloud/lean-cli/lean
 
 install: resources
 	GOOS=$(GOOS) go install github.com/leancloud/lean-cli/lean
 
 test:
 	sh test.sh
-	# go test -v github.com/leancloud/lean-cli/api
-	# go test -v github.com/leancloud/lean-cli/apps
-	# go test -v github.com/leancloud/lean-cli/boilerplate
-	# go test -v github.com/leancloud/lean-cli/console
-	# go test -v github.com/leancloud/lean-cli/stats
 
 resources:
 	(cd console; $(MAKE))

--- a/packaging/msi/lean-cli-x64.wxs
+++ b/packaging/msi/lean-cli-x64.wxs
@@ -12,7 +12,7 @@
     <Directory Id='TARGETDIR' Name='SourceDir'>
       <Directory Id="System64Folder" Name="SystemFolder">
         <Component Id='MainExecutable' Guid="*">
-          <File Id='LeanEXE' Name='lean.exe' DiskId='1' Source='_build/lean-windows-amd64.exe' KeyPath='yes'/>
+          <File Id='LeanEXE' Name='lean.exe' DiskId='1' Source='_build/lean-windows-x64.exe' KeyPath='yes'/>
         </Component>
       </Directory>
     </Directory>

--- a/packaging/msi/lean-cli-x86.wxs
+++ b/packaging/msi/lean-cli-x86.wxs
@@ -12,7 +12,7 @@
     <Directory Id='TARGETDIR' Name='SourceDir'>
       <Directory Id="SystemFolder" Name="SystemFolder">
         <Component Id='MainExecutable' Guid="*">
-          <File Id='LeanEXE' Name='lean.exe' DiskId='1' Source='_build/lean-windows-386.exe' KeyPath='yes'/>
+          <File Id='LeanEXE' Name='lean.exe' DiskId='1' Source='_build/lean-windows-x86.exe' KeyPath='yes'/>
         </Component>
       </Directory>
     </Directory>


### PR DESCRIPTION
顺便把编译结果改成 `x86` / `x64` 了，防止有的用户以为 `amd64` 只能在 amd 的机器上用。