### PR TITLE
:sparkles: support cancel while deploying #365

### DIFF
--- a/api/apps.go
+++ b/api/apps.go
@@ -53,7 +53,7 @@ func CancelDeployByToken(appId string, token string) error {
 		return err
 	}
 	client := NewClient(region)
-	resp, err := client.post("/1.1/engine/events/cancel"+token, nil, nil)
+	resp, err := client.post("/1.1/engine/events/cancel/"+token, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/api/apps.go
+++ b/api/apps.go
@@ -47,6 +47,22 @@ func GetAppList(region regions.Region) ([]*GetAppListResult, error) {
 	return result, nil
 }
 
+func CancelDeployByToken(appId string, token string) error {
+	region, err := GetAppRegion(appId)
+	if err != nil {
+		return err
+	}
+	client := NewClient(region)
+	resp, err := client.post("/1.1/engine/events/cancel"+token, nil, nil)
+	if err != nil {
+		return err
+	}
+	if !resp.Ok {
+		return NewErrorFromResponse(resp)
+	}
+	return nil
+}
+
 func deploy(appID string, group string, prod int, params map[string]interface{}) (*grequests.Response, error) {
 	region, err := GetAppRegion(appID)
 	if err != nil {

--- a/api/event_poller.go
+++ b/api/event_poller.go
@@ -3,14 +3,14 @@ package api
 import (
 	"fmt"
 	"os"
+	"os/signal"
 	"strings"
 	"time"
+	"sync"
 
 	"github.com/aisk/logp"
 	"github.com/fatih/color"
 	"github.com/mattn/go-colorable"
-	"os/signal"
-	"sync"
 )
 
 var (

--- a/api/event_poller.go
+++ b/api/event_poller.go
@@ -18,6 +18,12 @@ var (
 	ch = make(chan os.Signal)
 )
 
+func exitWithChannel(){
+	signal.Stop(ch)
+	close(ch)
+	os.Exit(0)
+}
+
 type deployEvent struct {
 	MoreEvent bool `json:"moreEvent"`
 	Events    []struct {
@@ -47,11 +53,10 @@ func monitorInterrupt(appId, eventTok string) {
 					logp.Info("取消部署成功！")
 				}
 				m.Unlock()
+				exitWithChannel()
 			}()
 		case 1:
-			signal.Stop(ch)
-			close(ch)
-			os.Exit(1)
+			exitWithChannel()
 		}
 	}
 }
@@ -60,10 +65,7 @@ func monitorInterrupt(appId, eventTok string) {
 func PollEvents(appID string, tok string) (bool, error) {
 	signal.Notify(ch, os.Interrupt)
 
-	defer func() {
-		signal.Stop(ch)
-		close(ch)
-	}()
+	defer exitWithChannel()
 
 	go monitorInterrupt(appID, tok)
 

--- a/commands/up_action.go
+++ b/commands/up_action.go
@@ -115,7 +115,7 @@ func upAction(c *cli.Context) error {
 	}
 
 	for k, v := range groupInfo.Environments {
-		localVar := os.Getenv(k);
+		localVar := os.Getenv(k)
 		if localVar == "" {
 			logp.Info("从服务器导出自定义环境变量：", k)
 			rtm.Envs = append(rtm.Envs, fmt.Sprintf("%s=%s", k, v))


### PR DESCRIPTION
1. 为什么使用了 Mutex？
在测试取消部署的过程中，出现了需要输入二次验证码情况。为了避免 `PollEvent` 和 `Get2FACode` 同时打印造成影响，使用 Mutex 限制 `stdout` 的写入。

2. 为什么在 `monitorInterrupt` 中，当 `i == 1`时不直接 `os.Exit(0)`？
`os.Exit(0)` 不会执行任何 `defer` 的内容。如果不在进程结束前关闭 `ch` 和终止信号传输到 `ch` 中的话，OS 依旧会默认继续把 `interrupt` 信号传到 `ch` 的内存地址（实际已经释放），导致之后程序运行会致使 `interrupt` 信号无效。（Go 1.7.3 测试。实际上，如果有任何好的写法既能执行先前 `defer` 的函数并且能够退出程序就可以避免这个冗余内容）