### PR TITLE
🌐 Fix `lean logs`

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -178,6 +178,9 @@ func (client *Client) checkAndDo2FA(resp *grequests.Response) (*grequests.Respon
 		return nil, err
 	}
 	token := result.Token
+	if token == "" {
+		return resp, nil
+	}
 	code, err := Get2FACode()
 	if err != nil {
 		return nil, err

--- a/api/log.go
+++ b/api/log.go
@@ -86,9 +86,7 @@ func ReceiveLogsByRange(printer LogReceiver, appID string, masterKey string, isP
 		if err != nil {
 			return err
 		}
-		for i := len(logs); i > 0; i-- {
-			log := logs[i-1]
-
+		for _, log := range logs {
 			logTime, err := time.Parse("2006-01-02T15:04:05.999999999Z", log.Time)
 			if err != nil {
 				return err

--- a/api/log.go
+++ b/api/log.go
@@ -72,7 +72,7 @@ func ReceiveLogsByLimit(printer LogReceiver, appID string, masterKey string, isP
 func ReceiveLogsByRange(printer LogReceiver, appID string, masterKey string, isProd bool, group string, from time.Time, to time.Time) error {
 	params := map[string]string{
 		"ascend":     "true",
-		"since":      from.Format("2006-01-02T15:04:05.000000000Z"),
+		"since":      from.UTC().Format("2006-01-02T15:04:05.000000000Z"),
 		"production": "0",
 		"group":      group,
 		"limit":      "1000",

--- a/commands/logs_action.go
+++ b/commands/logs_action.go
@@ -109,10 +109,10 @@ func getDefaultLogPrinter(isProd bool) api.LogReceiver {
 		}
 
 		if isProd {
-			fmt.Fprintf(color.Output, "%s %s %s\r\n", instance, levelSprintf(" %s ", t.Local().Format("15:04:05")), content)
+			fmt.Fprintf(color.Output, "%s %s %s\r\n", instance, levelSprintf(" %s ", formatTime(&t)), content)
 		} else {
 			// no instance column
-			fmt.Fprintf(color.Output, "%s %s\r\n", levelSprintf(" %s ", t.Local().Format("15:04:05")), content)
+			fmt.Fprintf(color.Output, "%s %s\r\n", levelSprintf(" %s ", formatTime(&t)), content)
 		}
 
 		return nil
@@ -126,4 +126,19 @@ func jsonLogPrinter(log *api.Log) error {
 	}
 	fmt.Println(string(content))
 	return nil
+}
+
+func isTimeInToday(t *time.Time) bool {
+	now := time.Now()
+	beginOfToday := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	endOfToday := beginOfToday.AddDate(0, 0, 1)
+	return t.After(beginOfToday) && t.Before(endOfToday)
+}
+
+func formatTime(t *time.Time) string {
+	if isTimeInToday(t) {
+		return t.Local().Format("15:04:05")
+	} else {
+		return t.Local().Format("2006-01-02 15:04:05")
+	}
 }

--- a/commands/logs_action.go
+++ b/commands/logs_action.go
@@ -16,7 +16,7 @@ func extractDateParams(c *cli.Context) (time.Time, time.Time, error) {
 	from := time.Time{}
 	var err error
 	if c.String("from") != "" {
-		from, err = time.Parse("2006-01-02", c.String("from"))
+		from, err = time.ParseInLocation("2006-01-02", c.String("from"), time.Now().Location())
 		if err != nil {
 			err = fmt.Errorf("from 参数格式错误：%s。正确格式为 YYYY-MM-DD，例如 1926-08-17", c.String("from"))
 			return time.Time{}, time.Time{}, err
@@ -24,7 +24,7 @@ func extractDateParams(c *cli.Context) (time.Time, time.Time, error) {
 	}
 	to := time.Time{}
 	if c.String("to") != "" {
-		to, err = time.Parse("2006-01-02", c.String("to"))
+		to, err = time.ParseInLocation("2006-01-02", c.String("to"), time.Now().Location())
 		if err != nil {
 			err = fmt.Errorf("to 参数格式错误：%s。正确格式为 YYYY-MM-DD，例如 1926-08-17", c.String("to"))
 			return time.Time{}, time.Time{}, err

--- a/packaging/deb/control-x64
+++ b/packaging/deb/control-x64
@@ -1,6 +1,6 @@
 Package: lean-cli
 Section: devel
-Version: 0.18.2
+Version: 0.18.3
 Priority: optional
 Architecture: amd64
 Maintainer: LeanCloud <support@leancloud.rocks>

--- a/packaging/deb/control-x86
+++ b/packaging/deb/control-x86
@@ -1,6 +1,6 @@
 Package: lean-cli
 Section: devel
-Version: 0.18.2
+Version: 0.18.3
 Priority: optional
 Architecture: i386
 Maintainer: LeanCloud <support@leancloud.rocks>

--- a/packaging/msi/lean-cli-x64.wxs
+++ b/packaging/msi/lean-cli-x64.wxs
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='windows-1252'?>
 <Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
   <Product Name='LeanCloud Command Line Tool (x64)' Id='*' UpgradeCode='2ED83D96-E449-4CD4-8655-3ED47886E48D'
-    Language='1033' Codepage='1252' Version='0.18.2.0' Manufacturer='LeanCloud'>
+    Language='1033' Codepage='1252' Version='0.18.3.0' Manufacturer='LeanCloud'>
 
     <Package Id='*' Keywords='Installer' Description="LeanCloud Command Line Tool Installer"
       Comments='LeanCLoud Command Line Tool Installer' Manufacturer='leancloud.cn' InstallerVersion='200' Languages='1033' Compressed='yes' SummaryCodepage='1252' />

--- a/packaging/msi/lean-cli-x86.wxs
+++ b/packaging/msi/lean-cli-x86.wxs
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='windows-1252'?>
 <Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
   <Product Name='LeanCloud Command Line Tool (x86)' Id='*' UpgradeCode='0A3A0119-23EF-4ADF-85FC-9DEC7BD0034A'
-    Language='1033' Codepage='1252' Version='0.18.2.0' Manufacturer='LeanCloud'>
+    Language='1033' Codepage='1252' Version='0.18.3.0' Manufacturer='LeanCloud'>
 
     <Package Id='*' Keywords='Installer' Description="LeanCloud Command Line Tool Installer"
       Comments='LeanCLoud Command Line Tool Installer' Manufacturer='leancloud.cn' InstallerVersion='200' Languages='1033' Compressed='yes' SummaryCodepage='1252' />

--- a/version/version.go
+++ b/version/version.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Version is lean-cli's version.
-const Version = "0.18.2"
+const Version = "0.18.3"
 
 func PrintCurrentVersion() {
 	logp.Info("当前命令行工具版本：", Version)


### PR DESCRIPTION
- 对于给 `lean logs` 传入的时间使用本地时区进行解析（之前是使用 UTC 解析）
- 修复 ReceiveLogsByRange 解析日志的顺序：当指定了 `ascend: true`，结果应该是顺序排列的
- 对于非当天日志，打印时带上日期
- 修复将所有 401 认为是需要两步认证的问题（现在会检查 token 字段是否为空）