### PR TITLE
✨ Support GitHub Action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ LABEL com.github.actions.color="blue"
 COPY --from=build /go/src/github.com/leancloud/lean-cli/_build/lean-linux-x64 /usr/bin/lean
 
 ENTRYPOINT ["lean"]
-CMD ["help"]
+CMD ["deploy", "--github-action"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM golang AS build
+
+WORKDIR /go/src/github.com/leancloud/lean-cli
+
+COPY . .
+
+RUN make binaries
+
+FROM debian
+
+LABEL version="0.20.0"
+LABEL repository="http://github.com/leancloud/lean-cli"
+LABEL homepage="http://github.com/leancloud/lean-cli"
+LABEL maintainer="LeanCloud <support@leancloud.rocks>"
+
+LABEL com.github.actions.name="GitHub Action for lean-cli"
+LABEL com.github.actions.description="Use the lean-cli to deploy to LeanEngine."
+LABEL com.github.actions.icon="deploy"
+LABEL com.github.actions.color="blue"
+
+COPY --from=build /go/src/github.com/leancloud/lean-cli/_build/lean-linux-x64 /usr/bin/lean
+
+ENTRYPOINT ["lean"]
+CMD ["help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,9 @@ LABEL com.github.actions.description="Use the lean-cli to deploy to LeanEngine."
 LABEL com.github.actions.icon="cpu"
 LABEL com.github.actions.color="blue"
 
+RUN apt-get update && apt-get install -y ca-certificates
+
 COPY --from=build /go/src/github.com/leancloud/lean-cli/_build/lean-linux-x64 /usr/bin/lean
 
 ENTRYPOINT ["lean"]
-CMD ["deploy", "--github-action"]
+CMD ["help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ LABEL maintainer="LeanCloud <support@leancloud.rocks>"
 
 LABEL com.github.actions.name="GitHub Action for lean-cli"
 LABEL com.github.actions.description="Use the lean-cli to deploy to LeanEngine."
-LABEL com.github.actions.icon="deploy"
+LABEL com.github.actions.icon="cpu"
 LABEL com.github.actions.color="blue"
 
 COPY --from=build /go/src/github.com/leancloud/lean-cli/_build/lean-linux-x64 /usr/bin/lean

--- a/api/event_poller.go
+++ b/api/event_poller.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/mattn/go-colorable"
+
+	"github.com/leancloud/lean-cli/api/regions"
 )
 
 type deployEvent struct {
@@ -20,15 +22,7 @@ type deployEvent struct {
 }
 
 // PollEvents will poll the server's event logs and print the result to the given io.Writer
-func PollEvents(appID string, tok string) (bool, error) {
-	client := NewClientByApp(appID)
-
-	opts, err := client.options()
-	if err != nil {
-		return false, err
-	}
-	opts.Headers["X-LC-Id"] = appID
-
+func PollEvents(client *Client, tok string) (bool, error) {
 	from := ""
 	ok := true
 	retryCount := 0
@@ -38,7 +32,7 @@ func PollEvents(appID string, tok string) (bool, error) {
 		if from != "" {
 			url = url + "?from=" + from
 		}
-		resp, err := client.get(url, opts)
+		resp, err := client.get(url, nil)
 		if err != nil {
 			retryCount++
 			if retryCount > 3 {
@@ -66,4 +60,12 @@ func PollEvents(appID string, tok string) (bool, error) {
 		}
 	}
 	return ok, nil
+}
+
+func PollEventsByApp(appID string, tok string) (bool, error) {
+	return PollEvents(NewClientByApp(appID), tok)
+}
+
+func PollEventsByRegion(region regions.Region, tok string) (bool, error) {
+	return PollEvents(NewClientByRegion(region), tok)
 }

--- a/commands/app.go
+++ b/commands/app.go
@@ -153,16 +153,18 @@ func Run(args []string) {
 				cli.BoolFlag{
 					Name: "keep-deploy-file",
 				},
-				cli.BoolFlag{
-					Name: "atomic",
-				},
-				cli.StringFlag{
-					Name: "build-root",
-				},
 				cli.StringFlag{
 					Name:  "revision,r",
 					Usage: "Git revision or branch. Only applicable when deploying from Git",
 					Value: "master",
+				},
+				cli.StringFlag{
+					Name:  "options",
+					Usage: "Send additional deploy options to server, in urlencode format(like `--options build-root=app&atomic=true`)",
+				},
+				cli.StringFlag{
+					Name:  "prod",
+					Usage: "Deploy to production(`--prod 1`) or staging(`--prod 0`) environment, default to staging if it exists",
 				},
 			},
 		},
@@ -171,8 +173,9 @@ func Run(args []string) {
 			Usage:  "Publish code from staging to production",
 			Action: wrapAction(publishAction),
 			Flags: []cli.Flag{
-				cli.BoolFlag{
-					Name: "atomic",
+				cli.StringFlag{
+					Name:  "options",
+					Usage: "Send additional deploy options to server, in urlencode format(like `--options build-root=app&atomic=true`)",
 				},
 			},
 		},

--- a/commands/app.go
+++ b/commands/app.go
@@ -166,6 +166,14 @@ func Run(args []string) {
 					Name:  "prod",
 					Usage: "Deploy to production(`--prod 1`) or staging(`--prod 0`) environment, default to staging if it exists",
 				},
+				cli.BoolFlag{
+					Name:  "github-action",
+					Usage: "Deploy from GitHub Action, use the commit triggered the workflow, should set a environment variable named `LEANCLOUD_WEBHOOK_TOKEN`",
+				},
+				cli.StringFlag{
+					Name:  "region",
+					Usage: "The LeanCloud region used by GitHub Action (e.g., US, CN)",
+				},
 			},
 		},
 		{

--- a/commands/deploy_action.go
+++ b/commands/deploy_action.go
@@ -191,7 +191,7 @@ func deployFromLocal(appID string, group string, prod int, isDeployFromJavaWar b
 	if err != nil {
 		return err
 	}
-	ok, err := api.PollEvents(appID, eventTok)
+	ok, err := api.PollEventsByApp(appID, eventTok)
 	if err != nil {
 		return err
 	}
@@ -206,7 +206,7 @@ func deployFromGit(appID string, group string, prod int, revision string, opts *
 	if err != nil {
 		return err
 	}
-	ok, err := api.PollEvents(appID, eventTok)
+	ok, err := api.PollEventsByApp(appID, eventTok)
 	if err != nil {
 		return err
 	}

--- a/commands/publish_action.go
+++ b/commands/publish_action.go
@@ -49,7 +49,7 @@ func publishAction(c *cli.Context) error {
 		Options: c.String("options"),
 	})
 
-	ok, err := api.PollEvents(appID, tok)
+	ok, err := api.PollEventsByApp(appID, tok)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## 用法

```
workflow "New workflow" {
  on = "push"
  resolves = ["leancloud/lean-cli@cf56662"]
}

action "leancloud/lean-cli@cf56662" {
  uses = "leancloud/lean-cli@action"
  secrets = ["LEANCLOUD_WEBHOOK_TOKEN"]
  args = "deploy --github-action"
}
```

- 在 GitHub Action 中使用 `leancloud/lean-cli` 作为 Action
- 必须配置一个名为 `LEANCLOUD_WEBHOOK_TOKEN` 的 secret.
- 必须在云引擎设置中将代码仓库改为 GitHub Action 所在的仓库（否则会找不到 Commit Hash）

此外还可以配置：

- 默认使用华北节点，如需使用其他节点需要修改 args 为 `deploy --github-action --region US`
- 默认部署到预备环境，如需部署到生产环境需要修改 args 为 `deploy --github-action --prod 1`
- 默认部署到 web 分组，如需使用其他分组需设置一个环境变量 `LEANCLOUD_APP_GROUP`，值是分组的名字
