### PR TITLE
feat: simplify local python version detection

### DIFF
--- a/runtimes/runtime.go
+++ b/runtimes/runtime.go
@@ -181,74 +181,29 @@ func lookupBin(fallbacks []string) (string, error) {
 }
 
 func newPythonRuntime(projectPath string) (*Runtime, error) {
-	// TODO: reafactor this shit
-	if config, err := getEngineConfig(projectPath); err == nil {
-		if config.CMD != "" {
-			return newPythonRuntimeFromEngineConfig(projectPath, config)
-		}
-	}
-	content, err := ioutil.ReadFile(filepath.Join(projectPath, ".python-version"))
-	if err != nil {
-		if !os.IsNotExist(err) {
-			return nil, err
-		}
-
-		execName := "python2.7"
-		content, err = ioutil.ReadFile(filepath.Join(projectPath, "runtime.txt"))
-		if err != nil {
-			if !os.IsNotExist(err) {
-				return nil, err
-			}
-			// the default content
-			content = []byte("python-2.7")
-		}
-		if strings.HasPrefix(string(content), "python-2.7") {
-			execName, err = lookupBin([]string{"python2.7", "python2", "python"})
-			if err != nil {
-				return nil, err
-			}
-		} else if strings.HasPrefix(string(content), "python-3.5") {
-			execName, err = lookupBin([]string{"python3.5", "python3", "python"})
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			return nil, errors.New("invalid python runtime.txt format, only `python-2.7` and `python-3.5` were allowed")
-		}
-
-		return &Runtime{
-			ProjectPath: projectPath,
-			Name:        "python",
-			Exec:        execName,
-			Args:        []string{"wsgi.py"},
-			Errors:      make(chan error),
-		}, nil
-	}
-	pythonVersion := string(content)
-	if !(strings.HasPrefix(pythonVersion, "2.") || strings.HasPrefix(pythonVersion, "3.")) {
-		return nil, errors.New("Wrong pyenv version. We only support CPython. Please check and correct .python-version")
-	}
-	logp.Info("pyenv detected. Please make sure pyenv is configured properly.")
-
-	return &Runtime{
+	runtime := &Runtime{
 		ProjectPath: projectPath,
 		Name:        "python",
 		Exec:        "python",
 		Args:        []string{"wsgi.py"},
 		Errors:      make(chan error),
-	}, nil
-}
-
-func newPythonRuntimeFromEngineConfig(projectPath string, config *engineConfig) (*Runtime, error) {
-	exec, args := config.parseCMD()
-	return &Runtime{
-		ProjectPath: projectPath,
-		Name:        "python",
-		Exec:        exec,
-		Args:        args,
-		Errors:      make(chan error),
-	}, nil
-
+	}
+	content, err := ioutil.ReadFile(filepath.Join(projectPath, ".python-version"))
+	if err == nil {
+		pythonVersion := string(content)
+		if strings.HasPrefix(pythonVersion, "2.") || strings.HasPrefix(pythonVersion, "3.") {
+			logp.Info("pyenv detected. Please make sure pyenv is configured properly.")
+			return runtime, nil
+		} else {
+			return nil, errors.New("Wrong pyenv version. We only support CPython. Please check and correct .python-version")
+		}
+	} else {
+		if os.IsNotExist(err) {
+			return runtime, nil
+		} else {
+			return nil, err
+		}
+	}
 }
 
 func newNodeRuntime(projectPath string) (*Runtime, error) {


### PR DESCRIPTION
1. Do not detect `leanengine.yaml` (intended to be used on cloud).
2. Do not detect `runtime.txt` (outdated, unsupported by cloud now).
3. Defaults to `python` instead of `python2.7` (EOL of py is coming).