### PR TITLE
 🔖 Release 0.21.0

### DIFF
--- a/api/engine.go
+++ b/api/engine.go
@@ -31,6 +31,7 @@ type GetGroupsResult struct {
 	Domain       string            `json:"domain"`
 	Instances    []InstanceInfo    `json:"instances"`
 	Staging      GroupDeployInfo   `json:"staging"`
+	Production   GroupDeployInfo   `json:"production"`
 	Environments map[string]string `json:"environments"`
 }
 

--- a/commands/switch_action.go
+++ b/commands/switch_action.go
@@ -162,15 +162,21 @@ func checkOutWithWizard(regionString string, groupName string) error {
 		return err
 	}
 
+	var filtedGroups []*api.GetGroupsResult
+
+	linq.From(groupList).Where(func(group interface{}) bool {
+		return group.(*api.GetGroupsResult).Staging.Deployable || group.(*api.GetGroupsResult).Production.Deployable
+	}).ToSlice(&filtedGroups)
+
 	var group *api.GetGroupsResult
 	if groupName == "" {
-		group, err = selectGroup(groupList)
+		group, err = selectGroup(filtedGroups)
 		if err != nil {
 			return err
 		}
 	} else {
 		err = func() error {
-			for _, group = range groupList {
+			for _, group = range filtedGroups {
 				if group.GroupName == groupName {
 					return nil
 				}

--- a/packaging/deb/control-x64
+++ b/packaging/deb/control-x64
@@ -1,6 +1,6 @@
 Package: lean-cli
 Section: devel
-Version: 0.20.1
+Version: 0.21.0
 Priority: optional
 Architecture: amd64
 Maintainer: LeanCloud <support@leancloud.rocks>

--- a/packaging/deb/control-x86
+++ b/packaging/deb/control-x86
@@ -1,6 +1,6 @@
 Package: lean-cli
 Section: devel
-Version: 0.20.1
+Version: 0.21.0
 Priority: optional
 Architecture: i386
 Maintainer: LeanCloud <support@leancloud.rocks>

--- a/packaging/msi/lean-cli-x64.wxs
+++ b/packaging/msi/lean-cli-x64.wxs
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='windows-1252'?>
 <Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
   <Product Name='LeanCloud Command Line Tool (x64)' Id='*' UpgradeCode='2ED83D96-E449-4CD4-8655-3ED47886E48D'
-    Language='1033' Codepage='1252' Version='0.20.1.0' Manufacturer='LeanCloud'>
+    Language='1033' Codepage='1252' Version='0.21.0.0' Manufacturer='LeanCloud'>
 
     <Package Id='*' Keywords='Installer' Description="LeanCloud Command Line Tool Installer"
       Comments='LeanCLoud Command Line Tool Installer' Manufacturer='leancloud.cn' InstallerVersion='200' Languages='1033' Compressed='yes' SummaryCodepage='1252' />

--- a/packaging/msi/lean-cli-x86.wxs
+++ b/packaging/msi/lean-cli-x86.wxs
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='windows-1252'?>
 <Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
   <Product Name='LeanCloud Command Line Tool (x86)' Id='*' UpgradeCode='0A3A0119-23EF-4ADF-85FC-9DEC7BD0034A'
-    Language='1033' Codepage='1252' Version='0.20.1.0' Manufacturer='LeanCloud'>
+    Language='1033' Codepage='1252' Version='0.21.0.0' Manufacturer='LeanCloud'>
 
     <Package Id='*' Keywords='Installer' Description="LeanCloud Command Line Tool Installer"
       Comments='LeanCLoud Command Line Tool Installer' Manufacturer='leancloud.cn' InstallerVersion='200' Languages='1033' Compressed='yes' SummaryCodepage='1252' />

--- a/version/version.go
+++ b/version/version.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Version is lean-cli's version.
-const Version = "0.20.1"
+const Version = "0.21.0"
 
 func PrintCurrentVersion() {
 	logp.Info("Current CLI tool version: ", Version)


### PR DESCRIPTION
https://github.com/leancloud/lean-cli/compare/v0.20.1...deployable

Changelog:

- 🔥 Remove `search` command.
- 💥 Remove `--atomic` and `--build-root` options for `deploy` command, you can use `--options` instead, like `lean deploy --options 'buildRoot=backend'`.
- 💥 `lean switch` will not display undeployable group.
- ✨ Add `--prod` for `deploy` command.
- ✨ `lean up` now working for [static](https://github.com/leancloud/static-getting-started) runtime.
- 🐛 `lean deploy` now deploy to staging for Client Engine as expected.
- Internal HTTP API changes.