### PR TITLE
docs: getSystemLanguage: friendlier locale error

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -258,7 +258,7 @@ func getSystemLanguage() string {
 	language, err := jibber_jabber.DetectLanguage()
 
 	if err != nil {
-		logp.Error(err)
+		logp.Error("unsupported locale setting: ", err)
 	}
 
 	return language


### PR DESCRIPTION
Previously, getSystemLanguage directly throws error message
of jibber_jabber.DetectLanguage(),
which is typically "Could not detect Language"
on systems with misconfigured locale.
This may confuse users that lean-cli cannot detect
runtime (programming) language correctly.
This commit added a prefix ("unsupported locale setting")
to the error message.

related issue: #426
related ticket: 20742