### PR TITLE
Lean cache 支持 LeanDB

### DIFF
--- a/api/leancache.go
+++ b/api/leancache.go
@@ -90,13 +90,8 @@ type LeanCacheInstance struct {
 func GetInstanceList(appID string) ([]*LeanCacheInstance, error) {
 	client := NewClientByApp(appID)
 
-	opts, err := client.options()
-	if err != nil {
-		return nil, err
-	}
-
 	url := fmt.Sprintf("/1.1/leandb/apps/%s/clusters", appID)
-	resp, err := client.get(url, opts)
+	resp, err := client.get(url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -115,15 +110,10 @@ func GetInstanceList(appID string) ([]*LeanCacheInstance, error) {
 func ExecuteInstanceCommand(appID string, instance string, db int, command string) (*ExecuteCacheCommandResult, error) {
 	client := NewClientByApp(appID)
 
-	opts, err := client.options()
-	if err != nil {
-		return nil, err
-	}
-
 	url := fmt.Sprintf("/1.1/leandb/clusters/%s/user-command/exec", instance)
 	resp, err := client.post(url, map[string]interface{}{
 		"db":      db,
-		"command": command}, opts)
+		"command": command}, nil)
 
 	if err != nil {
 		return nil, err

--- a/api/leancache.go
+++ b/api/leancache.go
@@ -78,16 +78,16 @@ func ExecuteCacheCommand(appID string, instance string, db int, command string) 
 	return result, err
 }
 
-// LeanCacheInstance is structure of LeanCache DB instannce
-type LeanCacheInstance struct {
+// LeanCacheCluster is structure of LeanCache DB instannce
+type LeanCacheCluster struct {
 	ID        int    `json:"id"`
 	Name      string `json:"name"`
 	Runtime   string `json:"runtime"`
 	NodeQuota string `json:"nodeQuota"`
 }
 
-// GetInstanceList returns current app's LeanCache instances (NEW)
-func GetInstanceList(appID string) ([]*LeanCacheInstance, error) {
+// GetClusterList returns current app's LeanCache instances (NEW)
+func GetClusterList(appID string) ([]*LeanCacheCluster, error) {
 	client := NewClientByApp(appID)
 
 	url := fmt.Sprintf("/1.1/leandb/apps/%s/clusters", appID)
@@ -96,7 +96,7 @@ func GetInstanceList(appID string) ([]*LeanCacheInstance, error) {
 		return nil, err
 	}
 
-	var result []*LeanCacheInstance
+	var result []*LeanCacheCluster
 	err = resp.JSON(&result)
 
 	if err != nil {
@@ -106,8 +106,8 @@ func GetInstanceList(appID string) ([]*LeanCacheInstance, error) {
 	return result, err
 }
 
-// ExecuteInstanceCommand will send command to LeanCache and excute it
-func ExecuteInstanceCommand(appID string, instance string, db int, command string) (*ExecuteCacheCommandResult, error) {
+// ExecuteClusterCommand will send command to LeanCache and excute it
+func ExecuteClusterCommand(appID string, instance string, db int, command string) (*ExecuteCacheCommandResult, error) {
 	client := NewClientByApp(appID)
 
 	url := fmt.Sprintf("/1.1/leandb/clusters/%s/user-command/exec", instance)
@@ -127,7 +127,7 @@ func ExecuteInstanceCommand(appID string, instance string, db int, command strin
 
 // GetVersion returns current app use LeanDB or LeanCache
 func GetVersion(appID string) (int, error) {
-	_, err := GetInstanceList(appID)
+	_, err := GetClusterList(appID)
 	if err != nil {
 		_, err := GetCacheList(appID)
 		if err != nil {

--- a/commands/app.go
+++ b/commands/app.go
@@ -276,7 +276,7 @@ func Run(args []string) {
 				cli.IntFlag{
 					Name:  "db",
 					Usage: "Number of LeanCache DB",
-					Value: -1,
+					Value: 0,
 				},
 				cli.StringFlag{
 					Name:  "name",

--- a/commands/cache_action.go
+++ b/commands/cache_action.go
@@ -134,8 +134,8 @@ func printCacheReult(result *api.ExecuteCacheCommandResult) error {
 }
 
 func cacheAction(c *cli.Context) error {
-	db := c.Int("db")
 	instanceName := c.String("name")
+	db := c.Int("db")
 	command := c.String("eval")
 
 	appID, err := apps.GetCurrentAppID(".")
@@ -143,7 +143,24 @@ func cacheAction(c *cli.Context) error {
 		return err
 	}
 
+	ver, err := api.GetVersion(appID)
+	if err != nil {
+		return err
+	}
+
+	switch ver {
+	case 0:
+		return runCacheAction(appID, instanceName, db, command)
+	case 1:
+		return runInstanceAction(appID, instanceName, db, command)
+	default:
+		return cli.NewExitError("The app cannot use lean cache.", 1)
+	}
+}
+
+func runCacheAction(appID string, instanceName string, db int, command string) error {
 	caches, err := api.GetCacheList(appID)
+
 	if err != nil {
 		return err
 	}
@@ -187,5 +204,125 @@ func cacheAction(c *cli.Context) error {
 		}
 	}
 
+	return nil
+}
+
+func runInstanceAction(appID string, instanceName string, db int, command string) error {
+	instances, err := api.GetInstanceList(appID)
+
+	if err != nil {
+		return err
+	}
+
+	if len(instances) == 0 {
+		return cli.NewExitError("This app doesn't have any LeanDB instance", 1)
+	}
+
+	if instanceName == "" {
+		instance, err := selectInstance(instances)
+		if err != nil {
+			return err
+		}
+		instanceName = instance.Name
+	}
+
+	if db == -1 {
+		db, err = selectDb()
+		if err != nil {
+			return err
+		}
+	}
+
+	if command == "" {
+		err = enterLeanDBREPL(appID, instanceName, db)
+		if err != nil {
+			return err
+		}
+	} else {
+		result, err := api.ExecuteInstanceCommand(appID, instanceName, db, command)
+		if e, ok := err.(api.Error); ok {
+			fmt.Println(e.Content)
+			return cli.NewExitError("", 1)
+		} else if err != nil {
+			return err
+		} else {
+			err = printCacheReult(result)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func selectInstance(cacheList []*api.LeanCacheInstance) (*api.LeanCacheInstance, error) {
+	var selectedInstance *api.LeanCacheInstance
+	question := wizard.Question{
+		Content: "Please choose a LeanCache instance",
+		Answers: []wizard.Answer{},
+	}
+	for _, instance := range cacheList {
+		answer := wizard.Answer{
+			Content: fmt.Sprintf("%s - %s", instance.Name, instance.NodeQuota),
+		}
+		// for scope problem
+		func(cache *api.LeanCacheInstance) {
+			answer.Handler = func() {
+				selectedInstance = instance
+			}
+		}(instance)
+		question.Answers = append(question.Answers, answer)
+	}
+	err := wizard.Ask([]wizard.Question{question})
+	return selectedInstance, err
+}
+
+func enterLeanDBREPL(appID string, instance string, db int) error {
+	l, err := readline.NewEx(&readline.Config{
+		Prompt:          fmt.Sprintf("LeanDB (db %d) > ", db),
+		HistoryFile:     filepath.Join(utils.ConfigDir(), "leancloud", "leandb_history"),
+		AutoComplete:    getRedisCommandCompleter(),
+		InterruptPrompt: "^C",
+		EOFPrompt:       "quit",
+	})
+	if err != nil {
+		return err
+	}
+	defer l.Close()
+
+	for {
+		line, err := l.Readline()
+		if err == readline.ErrInterrupt {
+			if len(line) == 0 {
+				break
+			} else {
+				continue
+			}
+		} else if line == "exit" || line == "quit" {
+			break
+		} else if err == io.EOF {
+			break
+		}
+
+		line = strings.TrimSpace(line)
+
+		if line == "" {
+			continue
+		} else if strings.HasPrefix(line, "select ") {
+		}
+
+		result, err := api.ExecuteInstanceCommand(appID, instance, db, line)
+		if e, ok := err.(api.Error); ok {
+			fmt.Println(e.Content)
+		} else if err != nil {
+			return err
+		} else {
+			err = printCacheReult(result)
+			if err != nil {
+				return err
+			}
+		}
+	}
 	return nil
 }

--- a/commands/cache_action.go
+++ b/commands/cache_action.go
@@ -208,7 +208,7 @@ func runCacheAction(appID string, instanceName string, db int, command string) e
 }
 
 func runInstanceAction(appID string, instanceName string, db int, command string) error {
-	instances, err := api.GetInstanceList(appID)
+	instances, err := api.GetClusterList(appID)
 
 	if err != nil {
 		return err
@@ -239,7 +239,7 @@ func runInstanceAction(appID string, instanceName string, db int, command string
 			return err
 		}
 	} else {
-		result, err := api.ExecuteInstanceCommand(appID, instanceName, db, command)
+		result, err := api.ExecuteClusterCommand(appID, instanceName, db, command)
 		if e, ok := err.(api.Error); ok {
 			fmt.Println(e.Content)
 			return cli.NewExitError("", 1)
@@ -256,8 +256,8 @@ func runInstanceAction(appID string, instanceName string, db int, command string
 	return nil
 }
 
-func selectInstance(cacheList []*api.LeanCacheInstance) (*api.LeanCacheInstance, error) {
-	var selectedInstance *api.LeanCacheInstance
+func selectInstance(cacheList []*api.LeanCacheCluster) (*api.LeanCacheCluster, error) {
+	var selectedInstance *api.LeanCacheCluster
 	question := wizard.Question{
 		Content: "Please choose a LeanCache instance",
 		Answers: []wizard.Answer{},
@@ -267,7 +267,7 @@ func selectInstance(cacheList []*api.LeanCacheInstance) (*api.LeanCacheInstance,
 			Content: fmt.Sprintf("%s - %s", instance.Name, instance.NodeQuota),
 		}
 		// for scope problem
-		func(cache *api.LeanCacheInstance) {
+		func(cache *api.LeanCacheCluster) {
 			answer.Handler = func() {
 				selectedInstance = instance
 			}
@@ -312,7 +312,7 @@ func enterLeanDBREPL(appID string, instance string, db int) error {
 		} else if strings.HasPrefix(line, "select ") {
 		}
 
-		result, err := api.ExecuteInstanceCommand(appID, instance, db, line)
+		result, err := api.ExecuteClusterCommand(appID, instance, db, line)
 		if e, ok := err.(api.Error); ok {
 			fmt.Println(e.Content)
 		} else if err != nil {

--- a/commands/cache_list_action.go
+++ b/commands/cache_list_action.go
@@ -16,6 +16,24 @@ func cacheListAction(c *cli.Context) error {
 		return err
 	}
 
+	ver, err := api.GetVersion(appID)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("lean cache version: %d\n", ver)
+
+	switch ver {
+	case 0:
+		return runCacheListAction(appID)
+	case 1:
+		return runInstanceListAction(appID)
+	default:
+		return cli.NewExitError("The app cannot use lean cache list.", 1)
+	}
+}
+
+func runCacheListAction(appID string) error {
 	caches, err := api.GetCacheList(appID)
 	if err != nil {
 		return err
@@ -30,6 +48,27 @@ func cacheListAction(c *cli.Context) error {
 	fmt.Fprintln(t, "InstanceName\tMaxMemory")
 	for _, cache := range caches {
 		fmt.Fprintf(t, "%s\t%dM\r\n", cache.Instance, cache.MaxMemory)
+	}
+	t.Flush()
+
+	return nil
+}
+
+func runInstanceListAction(appID string) error {
+	instances, err := api.GetInstanceList(appID)
+	if err != nil {
+		return err
+	}
+
+	if len(instances) == 0 {
+		return cli.NewExitError("This app doesn't have any LeanDB instance", 1)
+	}
+
+	t := tabwriter.NewWriter(os.Stdout, 0, 1, 3, ' ', 0)
+
+	fmt.Fprintln(t, "InstanceName\tQuota")
+	for _, instance := range instances {
+		fmt.Fprintf(t, "%s\t%s\r\n", instance.Name, instance.NodeQuota)
 	}
 	t.Flush()
 

--- a/commands/cache_list_action.go
+++ b/commands/cache_list_action.go
@@ -55,7 +55,7 @@ func runCacheListAction(appID string) error {
 }
 
 func runInstanceListAction(appID string) error {
-	instances, err := api.GetInstanceList(appID)
+	instances, err := api.GetClusterList(appID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## 相关 issue
https://github.com/leancloud/cloud-code/issues/1700

## 实现方式
1. 在 api/leancache.go 中增加了 LeanDB 接口实现
2. 复制 commands/cache_action.go 的 cacheAction 流程，根据 /1.1/leandb/apps/{appId}/clusters 返回结果确定版本分支流程，一支走 LeanCache 流程；一支走 LeanDB 流程（目前流程一致）
3. commands/cache_list_action.go 与 commands/cache_action.go 修改逻辑一致

## 测试
手动测试 

- lean cache
- lean cache --name=xx --eval=ping