### PR TITLE
feat: support overwrite-functions param for deploy and publish command

### DIFF
--- a/api/engine.go
+++ b/api/engine.go
@@ -38,6 +38,7 @@ type GetGroupsResult struct {
 type DeployOptions struct {
 	Message     string
 	NoDepsCache bool
+	OverwriteFuncs bool
 	Options     string // Additional options in urlencode format
 }
 
@@ -224,6 +225,7 @@ func PutEnvironments(appID string, group string, envs map[string]string) error {
 func prepareDeployParams(options *DeployOptions) (map[string]interface{}, error) {
 	params := map[string]interface{}{
 		"noDependenciesCache": options.NoDepsCache,
+		"overwriteFunctions": options.OverwriteFuncs,
 		"async":               true,
 	}
 

--- a/commands/app.go
+++ b/commands/app.go
@@ -139,6 +139,10 @@ func Run(args []string) {
 					Name:  "no-cache",
 					Usage: "Force download dependencies",
 				},
+				cli.BoolFlag{
+					Name:  "overwrite-functions",
+					Usage: "Overwrite cloud functions with the same name in other groups",
+				},
 				cli.StringFlag{
 					Name:  "leanignore",
 					Usage: "Rule file for ignored files in deployment",
@@ -171,6 +175,10 @@ func Run(args []string) {
 			Usage:  "Publish code from staging to production",
 			Action: wrapAction(publishAction),
 			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:  "overwrite-functions",
+					Usage: "Overwrite cloud functions with the same name in other groups",
+				},
 				cli.StringFlag{
 					Name:  "options",
 					Usage: "Send additional deploy options to server, in urlencode format(like `--options build-root=app&atomic=true`)",

--- a/commands/deploy_action.go
+++ b/commands/deploy_action.go
@@ -26,6 +26,7 @@ func deployAction(c *cli.Context) error {
 	isDeployFromJavaWar := c.Bool("war")
 	ignoreFilePath := c.String("leanignore")
 	noDepsCache := c.Bool("no-cache")
+	overwriteFuncs := c.Bool("overwrite-functions")
 	message := c.String("message")
 	keepFile := c.Bool("keep-deploy-file")
 	revision := c.String("revision")
@@ -81,6 +82,7 @@ func deployAction(c *cli.Context) error {
 
 	opts := &api.DeployOptions{
 		NoDepsCache: noDepsCache,
+		OverwriteFuncs: overwriteFuncs,
 		Options:     c.String("options"),
 	}
 

--- a/commands/publish_action.go
+++ b/commands/publish_action.go
@@ -46,6 +46,7 @@ func publishAction(c *cli.Context) error {
 	logp.Infof("Deploying %s(%s) to region: %s group: %s production\r\n", appInfo.AppName, appID, region, groupName)
 
 	tok, err := api.DeployImage(appID, groupName, 1, groupInfo.Staging.Version.VersionTag, &api.DeployOptions{
+		OverwriteFuncs: c.Bool("overwrite-functions"),
 		Options: c.String("options"),
 	})
 

--- a/version/version.go
+++ b/version/version.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Version is lean-cli's version.
-const Version = "0.23.0"
+const Version = "0.24.0"
 
 func PrintCurrentVersion() {
 	logp.Info("Current CLI tool version: ", Version)


### PR DESCRIPTION
Support `overwrite-functions` param for `deploy` and `publish` command.

Link issue: #451 