### PR TITLE
🔖 Prepare 0.25

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,9 @@ $(OUTPUT)/tds-windows-x64.exe: $(SRC) resources
 $(OUTPUT)/tds-macos-x64: $(SRC) resources
 	GOOS=darwin GOARCH=amd64 go build -o $@ -ldflags=$(LDFLAGS_TDS) github.com/leancloud/lean-cli/lean
 
+$(OUTPUT)/tds-macos-arm64: $(SRC) resources
+	GOOS=darwin GOARCH=arm64 go build -o $@ -ldflags=$(LDFLAGS_TDS) github.com/leancloud/lean-cli/lean
+
 $(OUTPUT)/tds-linux-x86: $(SRC) resources
 	GOOS=linux GOARCH=386 go build -o $@ -ldflags=$(LDFLAGS_TDS) github.com/leancloud/lean-cli/lean
 

--- a/api/client.go
+++ b/api/client.go
@@ -165,13 +165,13 @@ func doRequest(client *Client, method string, path string, params map[string]int
 	url := client.GetBaseURL() + path
 
 	if debuggingRequests() {
-		fmt.Printf("request(%v) [%s %s] %v %v\n", requestId, method, url, params, options.Headers)
+		fmt.Fprintf(os.Stderr, "request(%v) [%s %s] %v %v\n", requestId, method, url, params, options.Headers)
 	}
 
 	resp, err := fn(url, options)
 
 	if debuggingRequests() {
-		fmt.Printf("response(%v) [%s %s] %v %v %v\n", requestId, method, url, resp.StatusCode, resp.String(), resp.Header)
+		fmt.Fprintf(os.Stderr, "response(%v) [%s %s] %v %v %v\n", requestId, method, url, resp.StatusCode, resp.String(), resp.Header)
 	}
 
 	if err != nil {

--- a/api/regions/regions.go
+++ b/api/regions/regions.go
@@ -92,11 +92,16 @@ const (
 	ChinaTDS1
 )
 
-func GetLoginedRegions() []Region {
+// Only return available regions
+func GetLoginedRegions(availableRegions []Region) []Region {
 	var regions []Region
-	for k, v := range regionLoginStatus {
-		if v {
-			regions = append(regions, k)
+	for region, logged := range regionLoginStatus {
+		if logged {
+			for _, v := range availableRegions {
+				if region == v {
+					regions = append(regions, region)
+				}
+			}
 		}
 	}
 

--- a/commands/info_action.go
+++ b/commands/info_action.go
@@ -5,13 +5,14 @@ import (
 	"github.com/leancloud/lean-cli/api"
 	"github.com/leancloud/lean-cli/api/regions"
 	"github.com/leancloud/lean-cli/apps"
+	"github.com/leancloud/lean-cli/version"
 	"github.com/urfave/cli"
 )
 
 func infoAction(c *cli.Context) error {
 	callbacks := make([]func(), 0)
 
-	loginedRegions := regions.GetLoginedRegions()
+	loginedRegions := regions.GetLoginedRegions(version.AvailableRegions)
 
 	if len(loginedRegions) == 0 {
 		return cli.NewExitError("Please log in first", 1)

--- a/commands/init_action.go
+++ b/commands/init_action.go
@@ -9,6 +9,7 @@ import (
 	"github.com/leancloud/lean-cli/api/regions"
 	"github.com/leancloud/lean-cli/apps"
 	"github.com/leancloud/lean-cli/boilerplate"
+	"github.com/leancloud/lean-cli/version"
 	"github.com/urfave/cli"
 )
 
@@ -131,7 +132,7 @@ func initAction(c *cli.Context) error {
 	var region regions.Region
 	var err error
 	if regionString == "" {
-		loginedRegions := regions.GetLoginedRegions()
+		loginedRegions := regions.GetLoginedRegions(version.AvailableRegions)
 		if len(loginedRegions) == 0 {
 			return cli.NewExitError("Please log in first.", 1)
 		} else if len(loginedRegions) == 1 {

--- a/commands/switch_action.go
+++ b/commands/switch_action.go
@@ -120,7 +120,7 @@ func checkOutWithWizard(regionString string, groupName string) error {
 	var region regions.Region
 	var err error
 	if regionString == "" {
-		loginedRegions := regions.GetLoginedRegions()
+		loginedRegions := regions.GetLoginedRegions(version.AvailableRegions)
 		if len(loginedRegions) == 0 {
 			return cli.NewExitError("Please login first.", 1)
 		} else if len(loginedRegions) == 1 {

--- a/console/server.go
+++ b/console/server.go
@@ -79,7 +79,12 @@ func (server *Server) resourcesHandler(w http.ResponseWriter, req *http.Request)
 
 func (server *Server) appInfoHandler(w http.ResponseWriter, req *http.Request) {
 	url := fmt.Sprintf("%s/1.1/functions/_ops/metadatas", server.RemoteURL)
-	response, err := grequests.Options(url, &grequests.RequestOptions{})
+	response, err := grequests.Options(url, &grequests.RequestOptions{
+		Headers: map[string]string{
+			"Access-Control-Request-Method": "GET",
+			"Origin":                        fmt.Sprint("http://localhost:", server.ConsolePort),
+		},
+	})
 	if err != nil {
 		panic(err)
 	}

--- a/packaging/deb/control-x64
+++ b/packaging/deb/control-x64
@@ -1,6 +1,6 @@
 Package: lean-cli
 Section: devel
-Version: 0.24.4
+Version: 0.25.0
 Priority: optional
 Architecture: amd64
 Maintainer: LeanCloud <support@leancloud.rocks>

--- a/packaging/deb/control-x86
+++ b/packaging/deb/control-x86
@@ -1,6 +1,6 @@
 Package: lean-cli
 Section: devel
-Version: 0.24.4
+Version: 0.25.0
 Priority: optional
 Architecture: i386
 Maintainer: LeanCloud <support@leancloud.rocks>

--- a/packaging/msi/lean-cli-x64.wxs
+++ b/packaging/msi/lean-cli-x64.wxs
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='windows-1252'?>
 <Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
   <Product Name='LeanCloud Command Line Tool (x64)' Id='*' UpgradeCode='2ED83D96-E449-4CD4-8655-3ED47886E48D'
-    Language='1033' Codepage='1252' Version='0.24.4.0' Manufacturer='LeanCloud'>
+    Language='1033' Codepage='1252' Version='0.25.0.0' Manufacturer='LeanCloud'>
 
     <Package Id='*' Keywords='Installer' Description="LeanCloud Command Line Tool Installer"
       Comments='LeanCLoud Command Line Tool Installer' Manufacturer='leancloud.cn' InstallerVersion='200' Languages='1033' Compressed='yes' SummaryCodepage='1252' />

--- a/packaging/msi/lean-cli-x86.wxs
+++ b/packaging/msi/lean-cli-x86.wxs
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='windows-1252'?>
 <Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
   <Product Name='LeanCloud Command Line Tool (x86)' Id='*' UpgradeCode='0A3A0119-23EF-4ADF-85FC-9DEC7BD0034A'
-    Language='1033' Codepage='1252' Version='0.24.4.0' Manufacturer='LeanCloud'>
+    Language='1033' Codepage='1252' Version='0.25.0.0' Manufacturer='LeanCloud'>
 
     <Package Id='*' Keywords='Installer' Description="LeanCloud Command Line Tool Installer"
       Comments='LeanCLoud Command Line Tool Installer' Manufacturer='leancloud.cn' InstallerVersion='200' Languages='1033' Compressed='yes' SummaryCodepage='1252' />

--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Version is lean-cli's version.
-const Version = "0.24.4"
+const Version = "0.25.0"
 
 var Distribution = "lean"
 


### PR DESCRIPTION
- Built for TDS, support new `cn-tds1` region.
- Support login by Access Token (can be generated from dashboard), use `--token` to specify access token or `--use-token` for interactive input.
- Support direct upload (`lean deploy --direct`).
- HTTP request debug output `DEBUG=lean lean deploy`.
- Fix debug console for .Net apps.
