### PR TITLE
🔖 Release 0.25.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ $(OUTPUT)/lean-cli-x64.deb: $(OUTPUT)/lean-linux-x64
 $(OUTPUT)/tds-cli-x86.deb: $(OUTPUT)/tds-linux-x86
 	mkdir -p $(OUTPUT)/x86-deb/DEBIAN/
 	mkdir -p $(OUTPUT)/x86-deb/usr/bin/
-	cp $(OUTPUT)/tds-linux-x86 $(OUTPUT)/x86-deb/usr/bin/lean
+	cp $(OUTPUT)/tds-linux-x86 $(OUTPUT)/x86-deb/usr/bin/tds
 	cp packaging/deb/control-x86 $(OUTPUT)/x86-deb/DEBIAN/control
 	dpkg-deb --build $(OUTPUT)/x86-deb $@
 	rm -rf $(OUTPUT)/x86-deb
@@ -56,7 +56,7 @@ $(OUTPUT)/tds-cli-x86.deb: $(OUTPUT)/tds-linux-x86
 $(OUTPUT)/tds-cli-x64.deb: $(OUTPUT)/tds-linux-x64
 	mkdir -p $(OUTPUT)/x64-deb/DEBIAN/
 	mkdir -p $(OUTPUT)/x64-deb/usr/bin/
-	cp $(OUTPUT)/tds-linux-x64 $(OUTPUT)/x64-deb/usr/bin/lean
+	cp $(OUTPUT)/tds-linux-x64 $(OUTPUT)/x64-deb/usr/bin/tds
 	cp packaging/deb/control-x64 $(OUTPUT)/x64-deb/DEBIAN/control
 	dpkg-deb --build $(OUTPUT)/x64-deb $@
 	rm -rf $(OUTPUT)/x64-deb

--- a/packaging/deb/control-x64
+++ b/packaging/deb/control-x64
@@ -1,6 +1,6 @@
 Package: lean-cli
 Section: devel
-Version: 0.25.0
+Version: 0.25.1
 Priority: optional
 Architecture: amd64
 Maintainer: LeanCloud <support@leancloud.rocks>

--- a/packaging/deb/control-x86
+++ b/packaging/deb/control-x86
@@ -1,6 +1,6 @@
 Package: lean-cli
 Section: devel
-Version: 0.25.0
+Version: 0.25.1
 Priority: optional
 Architecture: i386
 Maintainer: LeanCloud <support@leancloud.rocks>

--- a/packaging/msi/lean-cli-x64.wxs
+++ b/packaging/msi/lean-cli-x64.wxs
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='windows-1252'?>
 <Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
   <Product Name='LeanCloud Command Line Tool (x64)' Id='*' UpgradeCode='2ED83D96-E449-4CD4-8655-3ED47886E48D'
-    Language='1033' Codepage='1252' Version='0.25.0.0' Manufacturer='LeanCloud'>
+    Language='1033' Codepage='1252' Version='0.25.1.0' Manufacturer='LeanCloud'>
 
     <Package Id='*' Keywords='Installer' Description="LeanCloud Command Line Tool Installer"
       Comments='LeanCLoud Command Line Tool Installer' Manufacturer='leancloud.cn' InstallerVersion='200' Languages='1033' Compressed='yes' SummaryCodepage='1252' />

--- a/packaging/msi/lean-cli-x86.wxs
+++ b/packaging/msi/lean-cli-x86.wxs
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='windows-1252'?>
 <Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
   <Product Name='LeanCloud Command Line Tool (x86)' Id='*' UpgradeCode='0A3A0119-23EF-4ADF-85FC-9DEC7BD0034A'
-    Language='1033' Codepage='1252' Version='0.25.0.0' Manufacturer='LeanCloud'>
+    Language='1033' Codepage='1252' Version='0.25.1.0' Manufacturer='LeanCloud'>
 
     <Package Id='*' Keywords='Installer' Description="LeanCloud Command Line Tool Installer"
       Comments='LeanCLoud Command Line Tool Installer' Manufacturer='leancloud.cn' InstallerVersion='200' Languages='1033' Compressed='yes' SummaryCodepage='1252' />

--- a/packaging/msi/tds-cli-x64.wxs
+++ b/packaging/msi/tds-cli-x64.wxs
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='windows-1252'?>
 <Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
   <Product Name='LeanCloud Command Line Tool (x64)' Id='*' UpgradeCode='2ED83D96-E449-4CD4-8655-3ED47886E48D'
-    Language='1033' Codepage='1252' Version='0.25.0.0' Manufacturer='LeanCloud'>
+    Language='1033' Codepage='1252' Version='0.25.1.0' Manufacturer='LeanCloud'>
 
     <Package Id='*' Keywords='Installer' Description="LeanCloud Command Line Tool Installer"
       Comments='LeanCLoud Command Line Tool Installer' Manufacturer='leancloud.cn' InstallerVersion='200' Languages='1033' Compressed='yes' SummaryCodepage='1252' />

--- a/packaging/msi/tds-cli-x86.wxs
+++ b/packaging/msi/tds-cli-x86.wxs
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='windows-1252'?>
 <Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
   <Product Name='LeanCloud Command Line Tool (x86)' Id='*' UpgradeCode='0A3A0119-23EF-4ADF-85FC-9DEC7BD0034A'
-    Language='1033' Codepage='1252' Version='0.25.0.0' Manufacturer='LeanCloud'>
+    Language='1033' Codepage='1252' Version='0.25.1.0' Manufacturer='LeanCloud'>
 
     <Package Id='*' Keywords='Installer' Description="LeanCloud Command Line Tool Installer"
       Comments='LeanCLoud Command Line Tool Installer' Manufacturer='leancloud.cn' InstallerVersion='200' Languages='1033' Compressed='yes' SummaryCodepage='1252' />

--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Version is lean-cli's version.
-const Version = "0.25.0"
+const Version = "0.25.1"
 
 var Distribution = "lean"
 


### PR DESCRIPTION
- Fix Debian deb package for tds-cli.
- Fix `LEANCLOUD_API_SERVER` for tds1 region.
- Embed debug console resources into lean-cli binary.