### PR TITLE
Prepare 1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 OUTPUT=./_build
 SRC=$(shell find . -iname "*.go")
 LDFLAGS='-X main.pkgType=binary -s -w'
-LDFLAGS_TDS="-X main.pkgType=binary -X github.com/leancloud/lean-cli/version.Distribution=tds -s -w"
 
 all: binaries msi deb
 
@@ -93,23 +92,23 @@ $(OUTPUT)/lean-linux-x86: $(SRC)
 $(OUTPUT)/lean-linux-x64: $(SRC)
 	GOOS=linux GOARCH=amd64 go build -o $@ -ldflags=$(LDFLAGS) github.com/leancloud/lean-cli/lean
 
-$(OUTPUT)/tds-windows-x86.exe: $(SRC)
-	GOOS=windows GOARCH=386 go build -o $@ -ldflags=$(LDFLAGS_TDS) github.com/leancloud/lean-cli/lean
+$(OUTPUT)/tds-windows-x86.exe: $(OUTPUT)/lean-windows-x86.exe
+	cp $< $@
 
-$(OUTPUT)/tds-windows-x64.exe: $(SRC)
-	GOOS=windows GOARCH=amd64 go build -o $@ -ldflags=$(LDFLAGS_TDS) github.com/leancloud/lean-cli/lean
+$(OUTPUT)/tds-windows-x64.exe: $(OUTPUT)/lean-windows-x64.exe
+	cp $< $@
 
-$(OUTPUT)/tds-macos-x64: $(SRC)
-	GOOS=darwin GOARCH=amd64 go build -o $@ -ldflags=$(LDFLAGS_TDS) github.com/leancloud/lean-cli/lean
+$(OUTPUT)/tds-macos-x64: $(OUTPUT)/lean-macos-x64
+	cp $< $@
 
-$(OUTPUT)/tds-macos-arm64: $(SRC)
-	GOOS=darwin GOARCH=arm64 go build -o $@ -ldflags=$(LDFLAGS_TDS) github.com/leancloud/lean-cli/lean
+$(OUTPUT)/tds-macos-arm64: $(OUTPUT)/lean-macos-arm64
+	cp $< $@
 
-$(OUTPUT)/tds-linux-x86: $(SRC)
-	GOOS=linux GOARCH=386 go build -o $@ -ldflags=$(LDFLAGS_TDS) github.com/leancloud/lean-cli/lean
+$(OUTPUT)/tds-linux-x86: $(OUTPUT)/lean-linux-x86
+	cp $< $@
 
-$(OUTPUT)/tds-linux-x64: $(SRC)
-	GOOS=linux GOARCH=amd64 go build -o $@ -ldflags=$(LDFLAGS_TDS) github.com/leancloud/lean-cli/lean
+$(OUTPUT)/tds-linux-x64: $(OUTPUT)/lean-linux-x64
+	cp $< $@
 
 install:
 	GOOS=$(GOOS) go install github.com/leancloud/lean-cli/lean

--- a/api/engine.go
+++ b/api/engine.go
@@ -45,6 +45,7 @@ type DeployOptions struct {
 	Message        string
 	NoDepsCache    bool
 	OverwriteFuncs bool
+	BuildLogs      bool
 	Options        string // Additional options in urlencode format
 }
 
@@ -278,6 +279,7 @@ func prepareDeployParams(options *DeployOptions) (map[string]interface{}, error)
 		"noDependenciesCache": options.NoDepsCache,
 		"overwriteFunctions":  options.OverwriteFuncs,
 		"async":               true,
+		"printBuildLogs":      options.BuildLogs,
 	}
 
 	if options.Message != "" {

--- a/api/regions/regions.go
+++ b/api/regions/regions.go
@@ -104,13 +104,9 @@ const (
 // Only return available regions
 func GetLoginedRegions(availableRegions []Region) []Region {
 	var regions []Region
-	for region, logged := range regionLoginStatus {
-		if logged {
-			for _, v := range availableRegions {
-				if region == v {
-					regions = append(regions, region)
-				}
-			}
+	for _, region := range availableRegions {
+		if regionLoginStatus[region] {
+			regions = append(regions, region)
 		}
 	}
 

--- a/boilerplate/boilerplate.go
+++ b/boilerplate/boilerplate.go
@@ -98,7 +98,7 @@ func FetchRepo(boil *Boilerplate, dest string, appID string) error {
 		}
 	}
 	// TODO: Change value of boil.Homepage for English site.
-	logp.Info("Creating ", boil.Name, " succeeded. Please refer to our website ", boil.Homepage, " for documentation about ", boil.Name)
+	logp.Info("Creating", boil.Name, "succeeded. Please refer to the website", boil.Homepage, "for documentation")
 	return nil
 }
 

--- a/commands/app.go
+++ b/commands/app.go
@@ -19,7 +19,7 @@ func Run(args []string) {
 	app := cli.NewApp()
 	app.Name = version.Distribution
 	app.Version = version.Version
-	app.Usage = "Command line to manage and deploy LeanCloud apps"
+	app.Usage = "Command line tool to manage and deploy LeanCloud apps"
 	app.EnableBashCompletion = true
 
 	app.CommandNotFound = thirdPartyCommand
@@ -233,7 +233,7 @@ func Run(args []string) {
 		},
 		{
 			Name:   "db",
-			Usage:  "List LeanDB instances under current app (include share instances)",
+			Usage:  "List, proxy, and connect to LeanDB instances",
 			Action: wrapAction(dbListAction),
 			Subcommands: []cli.Command{
 				{

--- a/commands/app.go
+++ b/commands/app.go
@@ -214,6 +214,10 @@ func Run(args []string) {
 					Name:  "direct",
 					Usage: "Upload project's tarball to remote directly",
 				},
+				cli.BoolFlag{
+					Name:  "build-logs",
+					Usage: "Print build logs",
+				},
 			},
 		},
 		{

--- a/commands/deploy_action.go
+++ b/commands/deploy_action.go
@@ -32,6 +32,7 @@ func deployAction(c *cli.Context) error {
 	revision := c.String("revision")
 	prodString := c.String("prod")
 	isDirect := c.Bool("direct")
+	buildLogs := c.Bool("build-logs")
 
 	var prod int
 
@@ -89,6 +90,7 @@ func deployAction(c *cli.Context) error {
 	opts := &api.DeployOptions{
 		NoDepsCache:    noDepsCache,
 		OverwriteFuncs: overwriteFuncs,
+		BuildLogs:      buildLogs,
 		Options:        c.String("options"),
 	}
 

--- a/commands/publish_action.go
+++ b/commands/publish_action.go
@@ -47,7 +47,7 @@ func publishAction(c *cli.Context) error {
 
 	tok, err := api.DeployImage(appID, groupName, 1, groupInfo.Staging.Version.VersionTag, &api.DeployOptions{
 		OverwriteFuncs: c.Bool("overwrite-functions"),
-		Options: c.String("options"),
+		Options:        c.String("options"),
 	})
 
 	ok, err := api.PollEvents(appID, tok)

--- a/version/version.go
+++ b/version/version.go
@@ -1,6 +1,10 @@
 package version
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/aisk/logp"
 	"github.com/leancloud/lean-cli/api/regions"
 )
@@ -8,9 +12,7 @@ import (
 // Version is lean-cli's version.
 const Version = "0.29.1"
 
-var Distribution = "lean"
-
-var LoginViaAccessTokenOnly = Distribution == "tds"
+var Distribution string
 
 var defaultRegionMapping = map[string]regions.Region{
 	"lean": regions.ChinaNorth,
@@ -22,8 +24,26 @@ var availableRegionsMapping = map[string][]regions.Region{
 	"tds":  {regions.ChinaTDS1, regions.APSG},
 }
 
-var DefaultRegion = defaultRegionMapping[Distribution]
-var AvailableRegions = availableRegionsMapping[Distribution]
+var LoginViaAccessTokenOnly bool
+var DefaultRegion regions.Region
+var AvailableRegions []regions.Region
+
+func init() {
+	Distribution = filepath.Base(os.Args[0])
+	Distribution = strings.TrimSuffix(Distribution, filepath.Ext(Distribution))
+	if idx := strings.Index(Distribution, "-"); idx != -1 {
+		Distribution = Distribution[:idx]
+	}
+	if Distribution != "lean" && Distribution != "tds" {
+		logp.Warnf("Invalid executable name: `%s`, falling back to `lean`.\n", Distribution)
+		logp.Warn("Please rename the executable to `lean` or `tds` depending on whether your app is on LeanCloud or TDS.")
+		Distribution = "lean"
+	}
+
+	LoginViaAccessTokenOnly = Distribution == "tds"
+	DefaultRegion = defaultRegionMapping[Distribution]
+	AvailableRegions = availableRegionsMapping[Distribution]
+}
 
 func PrintCurrentVersion() {
 	logp.Info("Current CLI tool version: ", Version)


### PR DESCRIPTION
- 三处措辞修改
- 将 `lean deploy --options 'printBuildLogs=true'` 改为更简单的 `lean deploy --build-logs`
- `lean init` 选择 region 时的顺序时常变化，修改为固定的顺序以方便快速选择
- 用命令的名字（`os.Args[0]`）来区分 `lean` 和 `tds`，方便 tds 加入 Homebrew（符号链接到 lean 即可）