### PR TITLE
move `lean upload` to `lean file upload`

### DIFF
--- a/commands/app.go
+++ b/commands/app.go
@@ -278,10 +278,16 @@ func Run(args []string) {
 			},
 		},
 		{
-			Name:      "upload",
-			Usage:     "Upload files to the current application (available in the '_File' class)",
-			Action:    uploadAction,
-			ArgsUsage: "<file-path> <file-path> ...",
+			Name:   "file",
+			Usage:  "Manage files",
+			Subcommands: []cli.Command{
+				{
+					Name:      "upload",
+					Usage:     "Upload files to the current application (available in the '_File' class)",
+					Action:    uploadAction,
+					ArgsUsage: "<file-path> <file-path> ...",
+				},
+			},
 		},
 		{
 			Name:   "logs",


### PR DESCRIPTION
将 `lean upload` 改为 `lean file upload`，避免和 `lean deploy` 混淆。另外方便以后添加下载、删除文件等功能。