### PR TITLE
🚑 Replace unavailable lncld.net

### DIFF
--- a/api/app_router.go
+++ b/api/app_router.go
@@ -34,7 +34,9 @@ func GetAppAPIURL(region regions.Region, appID string) string {
 	}
 
 	switch region {
-	case regions.ChinaNorth, regions.ChinaEast:
+	case regions.ChinaNorth:
+		return "https://" + strings.ToLower(appID[0:8]) + ".lc-cn-n1-shared.com"
+	case regions.ChinaEast:
 		routerInfo, err := QueryAppRouter(appID)
 
 		if err != nil {

--- a/packaging/deb/control-x64
+++ b/packaging/deb/control-x64
@@ -1,6 +1,6 @@
 Package: lean-cli
 Section: devel
-Version: 0.29.1
+Version: 0.29.2
 Priority: optional
 Architecture: amd64
 Maintainer: LeanCloud <support@leancloud.rocks>

--- a/packaging/deb/control-x86
+++ b/packaging/deb/control-x86
@@ -1,6 +1,6 @@
 Package: lean-cli
 Section: devel
-Version: 0.29.1
+Version: 0.29.2
 Priority: optional
 Architecture: i386
 Maintainer: LeanCloud <support@leancloud.rocks>

--- a/packaging/msi/lean-cli-x64.wxs
+++ b/packaging/msi/lean-cli-x64.wxs
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='windows-1252'?>
 <Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
   <Product Name='LeanCloud Command Line Tool (x64)' Id='*' UpgradeCode='2ED83D96-E449-4CD4-8655-3ED47886E48D'
-    Language='1033' Codepage='1252' Version='0.29.1.0' Manufacturer='LeanCloud'>
+    Language='1033' Codepage='1252' Version='0.29.2.0' Manufacturer='LeanCloud'>
 
     <Package Id='*' Keywords='Installer' Description="LeanCloud Command Line Tool Installer"
       Comments='LeanCLoud Command Line Tool Installer' Manufacturer='leancloud.cn' InstallerVersion='200' Languages='1033' Compressed='yes' SummaryCodepage='1252' />

--- a/packaging/msi/lean-cli-x86.wxs
+++ b/packaging/msi/lean-cli-x86.wxs
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='windows-1252'?>
 <Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
   <Product Name='LeanCloud Command Line Tool (x86)' Id='*' UpgradeCode='0A3A0119-23EF-4ADF-85FC-9DEC7BD0034A'
-    Language='1033' Codepage='1252' Version='0.29.1.0' Manufacturer='LeanCloud'>
+    Language='1033' Codepage='1252' Version='0.29.2.0' Manufacturer='LeanCloud'>
 
     <Package Id='*' Keywords='Installer' Description="LeanCloud Command Line Tool Installer"
       Comments='LeanCLoud Command Line Tool Installer' Manufacturer='leancloud.cn' InstallerVersion='200' Languages='1033' Compressed='yes' SummaryCodepage='1252' />

--- a/packaging/msi/tds-cli-x64.wxs
+++ b/packaging/msi/tds-cli-x64.wxs
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='windows-1252'?>
 <Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
   <Product Name='LeanCloud Command Line Tool (x64)' Id='*' UpgradeCode='2ED83D96-E449-4CD4-8655-3ED47886E48D'
-    Language='1033' Codepage='1252' Version='0.29.1.0' Manufacturer='LeanCloud'>
+    Language='1033' Codepage='1252' Version='0.29.2.0' Manufacturer='LeanCloud'>
 
     <Package Id='*' Keywords='Installer' Description="LeanCloud Command Line Tool Installer"
       Comments='LeanCLoud Command Line Tool Installer' Manufacturer='leancloud.cn' InstallerVersion='200' Languages='1033' Compressed='yes' SummaryCodepage='1252' />

--- a/packaging/msi/tds-cli-x86.wxs
+++ b/packaging/msi/tds-cli-x86.wxs
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='windows-1252'?>
 <Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
   <Product Name='LeanCloud Command Line Tool (x86)' Id='*' UpgradeCode='0A3A0119-23EF-4ADF-85FC-9DEC7BD0034A'
-    Language='1033' Codepage='1252' Version='0.29.1.0' Manufacturer='LeanCloud'>
+    Language='1033' Codepage='1252' Version='0.29.2.0' Manufacturer='LeanCloud'>
 
     <Package Id='*' Keywords='Installer' Description="LeanCloud Command Line Tool Installer"
       Comments='LeanCLoud Command Line Tool Installer' Manufacturer='leancloud.cn' InstallerVersion='200' Languages='1033' Compressed='yes' SummaryCodepage='1252' />

--- a/version/version.go
+++ b/version/version.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Version is lean-cli's version.
-const Version = "0.29.1"
+const Version = "0.29.2"
 
 var Distribution string
 


### PR DESCRIPTION
一个临时改动，之后再改成从 Domain Center 拉取自定义域名，因此这次也只改华北，避免引入新问题。

已检查过修改这里同时对 filesToken（lean deploy 时）和 lean up 有效。