### PR TITLE
移除 `lean deploy` 的默认环境，改为需要显式指定

### DIFF
--- a/commands/app.go
+++ b/commands/app.go
@@ -170,6 +170,18 @@ func Run(args []string) {
 			Action: wrapAction(deployAction),
 			Flags: []cli.Flag{
 				cli.BoolFlag{
+					Name:  "prod",
+					Usage: "Deploy to production environment",
+				},
+				cli.BoolFlag{
+					Name:  "staging",
+					Usage: "Deploy to staging environment",
+				},
+				cli.BoolFlag{
+					Name:  "build-logs",
+					Usage: "Print build logs",
+				},
+				cli.BoolFlag{
 					Name:  "g",
 					Usage: "Deploy from git repo",
 				},
@@ -206,17 +218,9 @@ func Run(args []string) {
 					Name:  "options",
 					Usage: "Send additional deploy options to server, in urlencode format(like `--options build-root=app&atomic=true`)",
 				},
-				cli.StringFlag{
-					Name:  "prod",
-					Usage: "Deploy to production(`--prod 1`) or staging(`--prod 0`) environment, default to staging if it exists",
-				},
 				cli.BoolFlag{
 					Name:  "direct",
 					Usage: "Upload project's tarball to remote directly",
-				},
-				cli.BoolFlag{
-					Name:  "build-logs",
-					Usage: "Print build logs",
 				},
 			},
 		},

--- a/commands/deploy_action.go
+++ b/commands/deploy_action.go
@@ -72,7 +72,7 @@ func deployAction(c *cli.Context) error {
 	} else if prodBool {
 		prod = 1
 	} else {
-		logp.Info("`lean deploy` now has no default environment, please add `--prod` or `--staging` flag")
+		logp.Info("`lean deploy` now has no default environment. Specify the target environment by `--prod` or `--staging` flag to avoid this prompt.")
 		question := wizard.Question{
 			Content: "Please select the environment: ",
 			Answers: []wizard.Answer{

--- a/commands/deploy_action.go
+++ b/commands/deploy_action.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/aisk/logp"
+	"github.com/aisk/wizard"
 	"github.com/leancloud/go-upload"
 	"github.com/leancloud/lean-cli/api"
 	"github.com/leancloud/lean-cli/api/regions"
@@ -30,7 +30,8 @@ func deployAction(c *cli.Context) error {
 	message := c.String("message")
 	keepFile := c.Bool("keep-deploy-file")
 	revision := c.String("revision")
-	prodString := c.String("prod")
+	prodBool := c.Bool("prod")
+	staging := c.Bool("staging")
 	isDirect := c.Bool("direct")
 	buildLogs := c.Bool("build-logs")
 
@@ -63,18 +64,38 @@ func deployAction(c *cli.Context) error {
 		return err
 	}
 
-	if prodString == "" {
-		if groupInfo.Staging.Deployable {
-			prod = 0
-		} else {
-			prod = 1
-		}
+	if staging && prodBool {
+		return cli.NewExitError("`--prod` and `--staging` flags are mutually exclusive", 1)
+	}
+	if staging {
+		prod = 0
+	} else if prodBool {
+		prod = 1
 	} else {
-		prod, err = strconv.Atoi(prodString)
+		logp.Info("`lean deploy` now has no default environment, please add `--prod` or `--staging` flag")
+		question := wizard.Question{
+			Content: "Please select the environment: ",
+			Answers: []wizard.Answer{
+				{
+					Content: "Production",
+					Handler: func() {
+						prod = 1
+					},
+				},
+				{
+					Content: "Staging",
+					Handler: func() {
+						prod = 0
+					},
+				},
+			},
+		}
+		err = wizard.Ask([]wizard.Question{question})
 		if err != nil {
 			return err
 		}
 	}
+
 	if prod == 0 && !groupInfo.Staging.Deployable {
 		return cli.NewExitError("Deployment failed: no staging instance", 1)
 	} else if prod == 1 && !groupInfo.Production.Deployable {

--- a/lean/main.go
+++ b/lean/main.go
@@ -40,6 +40,18 @@ func run() {
 		_ = checkUpdate()
 	}()
 
+	// In v1.0 `--prod 1` changed to `--prod`, and `--prod 0` changed to `--staging`.
+	for idx, arg := range os.Args {
+		if arg == "--prod" && idx+1 < len(os.Args) {
+			if os.Args[idx+1] == "0" {
+				os.Args[idx] = "--staging"
+				os.Args = append(os.Args[:idx+1], os.Args[idx+2:]...)
+			} else if os.Args[idx+1] == "1" {
+				os.Args = append(os.Args[:idx+1], os.Args[idx+2:]...)
+			}
+		}
+	}
+
 	commands.Run(os.Args)
 }
 


### PR DESCRIPTION
`lean deploy` 在不同付费方案下有着不同的行为，容易让用户困惑。这次调整后：

* 使用 `lean deploy --prod` 来部署生产环境
* 使用 `lean deploy --staging` 来部署预备环境
* `lean deploy` 会交互询问用户环境
* `lean deploy --prod 0|1` 仍然兼容