### PR TITLE
💄 Improve output of deploy and publish

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/aisk/logp"
 	"github.com/aisk/wizard"
 	"github.com/cloudfoundry-attic/jibber_jabber"
 	cookiejar "github.com/juju/persistent-cookiejar"
@@ -312,7 +311,7 @@ func getSystemLanguage() string {
 	language, err := jibber_jabber.DetectLanguage()
 
 	if err != nil {
-		logp.Info("unsupported locale setting & set to default en_US.UTF-8: ", err)
+		// unsupported locale setting (Could not detect Language)
 		language = "en"
 	}
 

--- a/commands/debug_action.go
+++ b/commands/debug_action.go
@@ -13,7 +13,7 @@ import (
 )
 
 func debugAction(c *cli.Context) error {
-	version.PrintCurrentVersion()
+	version.PrintVersionAndEnvironment()
 	remote := c.String("remote")
 	port := strconv.Itoa(c.Int("port"))
 	appID := c.String("app-id")

--- a/commands/up_action.go
+++ b/commands/up_action.go
@@ -30,7 +30,7 @@ func getConsolePort(runtimePort int) int {
 }
 
 func upAction(c *cli.Context) error {
-	version.PrintCurrentVersion()
+	version.PrintVersionAndEnvironment()
 	customArgs := c.Args()
 	customCommand := c.String("cmd")
 	rtmPort := c.Int("port")

--- a/version/version.go
+++ b/version/version.go
@@ -1,8 +1,10 @@
 package version
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/aisk/logp"
@@ -68,8 +70,9 @@ func init() {
 	DBBrandName = dbBrandNameMapping[Distribution]
 }
 
-func PrintCurrentVersion() {
-	logp.Info("Current CLI tool version: ", Version)
+func PrintVersionAndEnvironment() {
+	// Print all environment info to improve the efficiency of technical support
+	logp.Info(fmt.Sprintf("%s (v%s) running on %s/%s", os.Args[0], Version, runtime.GOOS, runtime.GOARCH))
 }
 
 func GetUserAgent() string {


### PR DESCRIPTION
- 去掉了似乎没什么意义的 `Could not detect Language` 打印
- 在版本信息中加入当前操作系统、架构、binary 名字
- 在 deploy 和 publish 里把部署目标拆成了两行（因为有 appName、appId、group、prod、region 这么多变量，一行很难写明白），其中的变量用绿色突出显示
- 去掉了对用户意义不大的 `Retrieving app info`（但这可能导致用户网络差的时候不知道 lean-cli 卡在哪里）、`Deleting temporary files` 打印

最后效果：

<img width="781" alt="image" src="https://user-images.githubusercontent.com/1191561/158976222-4e7e17b8-74e0-45ee-b4b3-75f62120ac80.png">
