### PR TITLE
quote env value to fix syntax error on multiline env

### DIFF
--- a/commands/app.go
+++ b/commands/app.go
@@ -365,7 +365,7 @@ func Run(args []string) {
 				},
 				cli.StringFlag{
 					Name:  "template",
-					Usage: "Template for output [default: export {{name}}={{value}}]",
+					Usage: "Template for output [default: export {{{name}}}={{{value}}}]",
 				},
 			},
 			Subcommands: []cli.Command{

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/onsi/ginkgo v1.14.0 // indirect
 	github.com/urfave/cli v1.19.1
 	golang.org/x/sys v0.0.0-20220624220833-87e55d714810 // indirect
+	gopkg.in/alessio/shellescape.v1 v1.0.0-20170105083845-52074bc9df61 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/cheggaaa/pb.v1 v1.0.28 // indirect
 	gopkg.in/errgo.v1 v1.0.0-20151007153157-66cb46252b94 // indirect

--- a/go.sum
+++ b/go.sum
@@ -182,6 +182,8 @@ google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miE
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyzM=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
+gopkg.in/alessio/shellescape.v1 v1.0.0-20170105083845-52074bc9df61 h1:8ajkpB4hXVftY5ko905id+dOnmorcS2CHNxxHLLDcFM=
+gopkg.in/alessio/shellescape.v1 v1.0.0-20170105083845-52074bc9df61/go.mod h1:IfMagxm39Ys4ybJrDb7W3Ob8RwxftP0Yy+or/NVz1O8=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20160105164936-4f90aeace3a2/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=

--- a/packaging/deb/control-x64
+++ b/packaging/deb/control-x64
@@ -1,6 +1,6 @@
 Package: lean-cli
 Section: devel
-Version: 1.0.1
+Version: 1.0.2
 Priority: optional
 Architecture: amd64
 Maintainer: LeanCloud <support@leancloud.rocks>

--- a/packaging/deb/control-x86
+++ b/packaging/deb/control-x86
@@ -1,6 +1,6 @@
 Package: lean-cli
 Section: devel
-Version: 1.0.1
+Version: 1.0.2
 Priority: optional
 Architecture: i386
 Maintainer: LeanCloud <support@leancloud.rocks>

--- a/packaging/msi/lean-cli-x64.wxs
+++ b/packaging/msi/lean-cli-x64.wxs
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='windows-1252'?>
 <Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
   <Product Name='LeanCloud Command Line Tool (x64)' Id='*' UpgradeCode='2ED83D96-E449-4CD4-8655-3ED47886E48D'
-    Language='1033' Codepage='1252' Version='1.0.1.0' Manufacturer='LeanCloud'>
+    Language='1033' Codepage='1252' Version='1.0.2.0' Manufacturer='LeanCloud'>
 
     <Package Id='*' Keywords='Installer' Description="LeanCloud Command Line Tool Installer"
       Comments='LeanCLoud Command Line Tool Installer' Manufacturer='leancloud.cn' InstallerVersion='200' Languages='1033' Compressed='yes' SummaryCodepage='1252' />

--- a/packaging/msi/lean-cli-x86.wxs
+++ b/packaging/msi/lean-cli-x86.wxs
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='windows-1252'?>
 <Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
   <Product Name='LeanCloud Command Line Tool (x86)' Id='*' UpgradeCode='0A3A0119-23EF-4ADF-85FC-9DEC7BD0034A'
-    Language='1033' Codepage='1252' Version='1.0.1.0' Manufacturer='LeanCloud'>
+    Language='1033' Codepage='1252' Version='1.0.2.0' Manufacturer='LeanCloud'>
 
     <Package Id='*' Keywords='Installer' Description="LeanCloud Command Line Tool Installer"
       Comments='LeanCLoud Command Line Tool Installer' Manufacturer='leancloud.cn' InstallerVersion='200' Languages='1033' Compressed='yes' SummaryCodepage='1252' />

--- a/packaging/msi/tds-cli-x64.wxs
+++ b/packaging/msi/tds-cli-x64.wxs
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='windows-1252'?>
 <Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
   <Product Name='LeanCloud Command Line Tool (x64)' Id='*' UpgradeCode='2ED83D96-E449-4CD4-8655-3ED47886E48D'
-    Language='1033' Codepage='1252' Version='1.0.1.0' Manufacturer='LeanCloud'>
+    Language='1033' Codepage='1252' Version='1.0.2.0' Manufacturer='LeanCloud'>
 
     <Package Id='*' Keywords='Installer' Description="LeanCloud Command Line Tool Installer"
       Comments='LeanCLoud Command Line Tool Installer' Manufacturer='leancloud.cn' InstallerVersion='200' Languages='1033' Compressed='yes' SummaryCodepage='1252' />

--- a/packaging/msi/tds-cli-x86.wxs
+++ b/packaging/msi/tds-cli-x86.wxs
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='windows-1252'?>
 <Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
   <Product Name='LeanCloud Command Line Tool (x86)' Id='*' UpgradeCode='0A3A0119-23EF-4ADF-85FC-9DEC7BD0034A'
-    Language='1033' Codepage='1252' Version='1.0.1.0' Manufacturer='LeanCloud'>
+    Language='1033' Codepage='1252' Version='1.0.2.0' Manufacturer='LeanCloud'>
 
     <Package Id='*' Keywords='Installer' Description="LeanCloud Command Line Tool Installer"
       Comments='LeanCLoud Command Line Tool Installer' Manufacturer='leancloud.cn' InstallerVersion='200' Languages='1033' Compressed='yes' SummaryCodepage='1252' />

--- a/version/version.go
+++ b/version/version.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Version is lean-cli's version.
-const Version = "1.0.1"
+const Version = "1.0.2"
 
 var Distribution string
 


### PR DESCRIPTION
fixes #508 

- 用 https://github.com/alessio/shellescape 来转义
- 输出模版由 `{{` 改为 `{{{` 来关闭 HTML 转义 `'` https://github.com/cbroglie/mustache#escaping
- Windows 不用转义，因为 `SET name=v a l` 中等号后面全部都视为值

另外 shellescape 的实现也很有意思，它有一个白名单 `\w@%+=:,./-`，如果输入都在白名单内不做任何操作。如果出现了白名单外的字符，会在输入前后加单引号 `'`，因为 bash 中单引号字符串就是最纯粹的字符串，不会有插值之类的操作。唯一的问题就是如果输入本来就包含单引号会造成不匹配，而且无法通过用其他编程语言中常见的 `\'` 来表示，因为 bash 中 [ANSI-C Quoting](https://www.gnu.org/software/bash/manual/html_node/ANSI_002dC-Quoting.html) 需要用 `$''` 字符串才行。shellescape 中是利用了 C 系语言中字符串的一个特性：相邻的字面量字符串会自动拼接在一起：
```bash
$ echo 'a''b'
ab
```
它会将原来存在的单引号 `'` 替换成 `'"'"'` （单双单双单）。两边的单引号用来配对之前对前后添加的单引号，中间是双引号中间的单引号 `"'"`，也就是长度为一的字符串。综上，原字符串 `a'b` 会变成三个字符串 `'a' "'" 'b'`（添加了空格帮助阅读）。