### PR TITLE
fix(boilerplate): create Vue apps with Vite

### DIFF
--- a/boilerplate/boilerplate.go
+++ b/boilerplate/boilerplate.go
@@ -161,14 +161,14 @@ var Boilerplates = []Boilerplate{
 		Name:  "React Web App (via create-react-app)",
 		Files: prepareWebAppFiles("build"),
 		CMD: func(dest string) []string {
-			return []string{"npx", "create-react-app", dest, "--use-npm"}
+			return []string{"npx", "create-react-app", dest}
 		},
 	},
 	{
-		Name:  "Vue Web App (via @vue/cli)",
+		Name:  "Vue Web App (via create-vite)",
 		Files: prepareWebAppFiles("dist"),
 		CMD: func(dest string) []string {
-			return []string{"npx", "@vue/cli", "create", "--default", "--packageManager", "npm", dest}
+			return []string{"npx", "create-vite", dest, "--template", "vue"}
 		},
 	},
 }


### PR DESCRIPTION
因为 [@vue/cli](https://cli.vuejs.org/) 停止维护了，所以我试着把通过 `lean new` 创建 Vue 项目的工具换成了 [create-vite](https://vitejs.dev/)。但现在遇到了一个小问题，就是由于以下这三种情况同时存在，导致如果开发者直接把通过 create-vite 创建的项目使用 `lean deploy` 进行部署（而不预先手动执行一次 `npm install`），会遇到因为云端环境缺少 vite 这一依赖而无法构建的错误：

1. Vite 会把构建项目所需的 vite 和 @vitejs/plugin-vue 这两个依赖放入 `devDependencies`；
2. Vite 创建好项目后，不会自动运行 `npm install`，所以项目中默认只有 package.json，不会有 package-lock.json；
3. 如果项目中不存在 package-lock.json，云引擎会使用 `npm install --production` 安装依赖，这意味着 `devDependencies` 中的依赖不会被安装。

需要想一个办法解决这个问题。