### PR TITLE
:alien: switch to client center api

### DIFF
--- a/api/apps.go
+++ b/api/apps.go
@@ -7,11 +7,11 @@ import (
 
 // GetAppListResult is GetAppList function's result type
 type GetAppListResult struct {
-	AppID     string `json:"app_id"`
-	AppKey    string `json:"app_key"`
-	AppName   string `json:"app_name"`
-	MasterKey string `json:"master_key"`
-	AppDomain string `json:"app_domain"`
+	AppID     string `json:"appId"`
+	AppKey    string `json:"appKey"`
+	AppName   string `json:"appName"`
+	MasterKey string `json:"masterKey"`
+	AppDomain string `json:"appDomain"`
 }
 
 // GetAppList returns the current user's all LeanCloud application
@@ -19,7 +19,7 @@ type GetAppListResult struct {
 func GetAppList(region regions.Region) ([]*GetAppListResult, error) {
 	client := NewClientByRegion(region)
 
-	resp, err := client.get("/1/clients/self/apps", nil)
+	resp, err := client.get("/client-center/2/clients/self/apps", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -43,19 +43,19 @@ func GetAppList(region regions.Region) ([]*GetAppListResult, error) {
 
 // GetAppInfoResult is GetAppInfo function's result type
 type GetAppInfoResult struct {
-	AppDomain string `json:"app_domain"`
-	AppID     string `json:"app_id"`
-	AppKey    string `json:"app_key"`
-	AppName   string `json:"app_name"`
-	HookKey   string `json:"hook_key"`
-	MasterKey string `json:"master_key"`
+	AppDomain string `json:"appDomain"`
+	AppID     string `json:"appId"`
+	AppKey    string `json:"appKey"`
+	AppName   string `json:"appName"`
+	HookKey   string `json:"hookKey"`
+	MasterKey string `json:"masterKey"`
 }
 
 // GetAppInfo returns the application's detail info
 func GetAppInfo(appID string) (*GetAppInfoResult, error) {
 	client := NewClientByApp(appID)
 
-	resp, err := client.get("/1.1/clients/self/apps/"+appID, nil)
+	resp, err := client.get("/client-center/2/clients/self/apps/"+appID, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/api/client.go
+++ b/api/client.go
@@ -140,7 +140,6 @@ func (client *Client) GetAuthHeaders() map[string]string {
 			if cookie.Name == "uluru_user" || cookie.Name == "XSRF-TOKEN" {
 				client.CookieJar.RemoveAllHost(url.Host)
 				client.CookieJar.Save()
-				panic("Please log in")
 			}
 		}
 

--- a/api/client.go
+++ b/api/client.go
@@ -134,7 +134,13 @@ func (client *Client) GetAuthHeaders() map[string]string {
 		for _, cookie := range cookies {
 			if cookie.Name == "csrf-token" {
 				csrf = cookie.Value
-				break
+			}
+
+			// unsupported uluru cookie
+			if cookie.Name == "uluru_user" || cookie.Name == "XSRF-TOKEN" {
+				client.CookieJar.RemoveAllHost(url.Host)
+				client.CookieJar.Save()
+				panic("Please log in")
 			}
 		}
 

--- a/commands/action_warpper.go
+++ b/commands/action_warpper.go
@@ -2,11 +2,11 @@ package commands
 
 import (
 	"fmt"
-	"github.com/leancloud/lean-cli/apps"
 	"strings"
 
 	"github.com/fatih/color"
 	"github.com/leancloud/lean-cli/api"
+	"github.com/leancloud/lean-cli/apps"
 	"github.com/urfave/cli"
 )
 
@@ -33,8 +33,8 @@ func wrapAction(action cli.ActionFunc) cli.ActionFunc {
 		case api.Error:
 			var msg string
 			// Make error message more friendly to users having applications at multi regions.
-			if e.Code == 1 && strings.HasPrefix(e.Content, "User doesn't sign in.") {
-				msg = msgWithRegion(e.Content)
+			if strings.HasPrefix(e.Content, "unauthorized") {
+				msg = msgWithRegion("User doesn't sign in.")
 			} else {
 				msg = e.Content
 			}

--- a/commands/app.go
+++ b/commands/app.go
@@ -290,7 +290,7 @@ func Run(args []string) {
 				{
 					Name:      "upload",
 					Usage:     "Upload files",
-					Action:    uploadAction,
+					Action:    wrapAction(uploadAction),
 					ArgsUsage: "<file-path>...",
 				},
 			},

--- a/commands/switch_action.go
+++ b/commands/switch_action.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/ahmetalpbalkan/go-linq"
 	"github.com/aisk/logp"
@@ -219,7 +218,7 @@ func switchAction(c *cli.Context) error {
 		arg := c.Args()[0]
 		err := checkOutWithAppInfo(arg, region, group)
 		if err != nil {
-			return handlerSwitchErr(err, region)
+			return err
 		}
 		return nil
 	}
@@ -229,12 +228,4 @@ func switchAction(c *cli.Context) error {
 func checkOutAction(c *cli.Context) error {
 	logp.Warn("`lean checkout` is deprecated, please use `lean switch` instead")
 	return switchAction(c)
-}
-
-func handlerSwitchErr(err error, region string) error {
-	e, ok := err.(api.Error)
-	if ok && e.Code == 1 && strings.HasPrefix(e.Content, "User doesn't sign in.") {
-		return cli.NewExitError(fmt.Sprintf("User doesn't sign in at region %s.", region), 1)
-	}
-	return err
 }


### PR DESCRIPTION
命令行工具切换到使用 client center 提供的接口。

- 除了更改请求的地址之外，就是将两步验证部分删掉了（原有的接口在新的 client center 中已经不支持），改为仅在登录时判断是否需要两步验证、如果需要再带上 code 重新请求登录接口。

- 已经在本地 build 之后测试了所有[子命令](https://docs.leancloud.cn/sdk/engine/cli/#%E5%91%BD%E4%BB%A4%E4%BB%8B%E7%BB%8D)，没有问题。

剩下一个有点纠结的点是，如果用户升级新版，原有的存在本地的 XSRF-TOKEN 会用不了（header 里不再带上），部分请求会报错 `[ERROR] unauthorized`。用户重新登录就好了，但这个提示不太友好（这里没有兼容 uluru 的 XSRF-TOKEN 是因为命令行工具的 cookie 过期时间太长了，之后 uluru 彻底不用，还是要报错、要改，不如现在就 👋）。

在 cd77bc9 试了删掉 uluru cookie，这里我能 panic 一下吗（或者你们看怎么改更合适。