### PR TITLE
Fix GITHUB_REF is wrong for jobs triggered with closed PRs

### DIFF
--- a/packaging/deb/control-x64
+++ b/packaging/deb/control-x64
@@ -1,6 +1,6 @@
 Package: lean-cli
 Section: devel
-Version: 1.2.2
+Version: 1.2.3
 Priority: optional
 Architecture: amd64
 Maintainer: LeanCloud <support@leancloud.rocks>

--- a/packaging/deb/control-x86
+++ b/packaging/deb/control-x86
@@ -1,6 +1,6 @@
 Package: lean-cli
 Section: devel
-Version: 1.2.2
+Version: 1.2.3
 Priority: optional
 Architecture: i386
 Maintainer: LeanCloud <support@leancloud.rocks>

--- a/packaging/msi/lean-cli-x64.wxs
+++ b/packaging/msi/lean-cli-x64.wxs
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='windows-1252'?>
 <Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
   <Product Name='LeanCloud Command Line Tool (x64)' Id='*' UpgradeCode='2ED83D96-E449-4CD4-8655-3ED47886E48D'
-    Language='1033' Codepage='1252' Version='1.2.2.0' Manufacturer='LeanCloud'>
+    Language='1033' Codepage='1252' Version='1.2.3.0' Manufacturer='LeanCloud'>
 
     <Package Id='*' Keywords='Installer' Description="LeanCloud Command Line Tool Installer"
       Comments='LeanCLoud Command Line Tool Installer' Manufacturer='leancloud.cn' InstallerVersion='200' Languages='1033' Compressed='yes' SummaryCodepage='1252' />

--- a/packaging/msi/lean-cli-x86.wxs
+++ b/packaging/msi/lean-cli-x86.wxs
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='windows-1252'?>
 <Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
   <Product Name='LeanCloud Command Line Tool (x86)' Id='*' UpgradeCode='0A3A0119-23EF-4ADF-85FC-9DEC7BD0034A'
-    Language='1033' Codepage='1252' Version='1.2.2.0' Manufacturer='LeanCloud'>
+    Language='1033' Codepage='1252' Version='1.2.3.0' Manufacturer='LeanCloud'>
 
     <Package Id='*' Keywords='Installer' Description="LeanCloud Command Line Tool Installer"
       Comments='LeanCLoud Command Line Tool Installer' Manufacturer='leancloud.cn' InstallerVersion='200' Languages='1033' Compressed='yes' SummaryCodepage='1252' />

--- a/packaging/msi/tds-cli-x64.wxs
+++ b/packaging/msi/tds-cli-x64.wxs
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='windows-1252'?>
 <Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
   <Product Name='LeanCloud Command Line Tool (x64)' Id='*' UpgradeCode='2ED83D96-E449-4CD4-8655-3ED47886E48D'
-    Language='1033' Codepage='1252' Version='1.2.2.0' Manufacturer='LeanCloud'>
+    Language='1033' Codepage='1252' Version='1.2.3.0' Manufacturer='LeanCloud'>
 
     <Package Id='*' Keywords='Installer' Description="LeanCloud Command Line Tool Installer"
       Comments='LeanCLoud Command Line Tool Installer' Manufacturer='leancloud.cn' InstallerVersion='200' Languages='1033' Compressed='yes' SummaryCodepage='1252' />

--- a/packaging/msi/tds-cli-x86.wxs
+++ b/packaging/msi/tds-cli-x86.wxs
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='windows-1252'?>
 <Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
   <Product Name='LeanCloud Command Line Tool (x86)' Id='*' UpgradeCode='0A3A0119-23EF-4ADF-85FC-9DEC7BD0034A'
-    Language='1033' Codepage='1252' Version='1.2.2.0' Manufacturer='LeanCloud'>
+    Language='1033' Codepage='1252' Version='1.2.3.0' Manufacturer='LeanCloud'>
 
     <Package Id='*' Keywords='Installer' Description="LeanCloud Command Line Tool Installer"
       Comments='LeanCLoud Command Line Tool Installer' Manufacturer='leancloud.cn' InstallerVersion='200' Languages='1033' Compressed='yes' SummaryCodepage='1252' />

--- a/version/version.go
+++ b/version/version.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Version is lean-cli's version.
-const Version = "1.2.2"
+const Version = "1.2.3"
 
 var Distribution string
 


### PR DESCRIPTION
GitHub 这太坑了……先是 GITHUB_SHA 指向的是 PR 要合并到的 commit，而不是 PR 最新的 commit（在 push 等其他事件中却指向的是要 push 的 commit）；再是 GITHUB_REF 在创建 PR 的时候是对的，但合并 PR 的时候就不对了……文档中只字未提，只有遇到了才能发现……